### PR TITLE
Update parse_draft_log.go

### DIFF
--- a/pkg/commands/parse_draft_log.go
+++ b/pkg/commands/parse_draft_log.go
@@ -23,7 +23,7 @@ var DraftLogCmd = &cobra.Command{
 func init() {
 	// Add flags for the command to parse a single deck.
 	flags := DraftLogCmd.Flags()
-	flag.StringVarP(flags, &fileType, "log-file", "f", "", "", "Path to the draft log file to parse.")
+	flag.StringVarP(flags, &draftLog, "log-file", "f", "", "", "Path to the draft log file to parse.")
 	flag.StringVarP(flags, &date, "date", "t", "DATE", "", "Date, in YYYY-MM-DD format")
 }
 


### PR DESCRIPTION
"parse_draft_log" command was broken because it didn't recognise the draft logfile parameter.