### PR TITLE
Add make ut target and CI workflow for unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  ut:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run unit tests
+        run: make ut

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ GO_FILES=$(shell find ./pkg -type f) $(shell find ./cmd -type f)
 all: data/oracle-cards.json bin/parser
 build: bin/server bin/parser
 
-test:
+test: ut
+
+ut:
 	go test ./...
 
 index: data/oracle-cards.json


### PR DESCRIPTION
Add a \`make ut\` target that runs \`go test ./...\` and a GitHub Actions workflow that invokes it on PRs and pushes to main. The existing \`test\` target is kept as an alias for \`ut\`.