### PR TITLE
Make deck archetype, tags, and colors editable in the UI

### DIFF
--- a/ui/src/components/TagEditor.js
+++ b/ui/src/components/TagEditor.js
@@ -1,0 +1,63 @@
+import React, { useState, useId } from 'react'
+
+// TagEditor renders the current tags as removable pills plus a text input with
+// datalist autocomplete. onChange fires with the complete new tag list whenever
+// a tag is added (Enter) or removed (pill x). Duplicates and blanks are ignored.
+export function TagEditor({ tags, suggestions, onChange }) {
+  const [text, setText] = useState("")
+  const current = tags || []
+  // Unique per instance so multiple TagEditors on one page (e.g. the selected
+  // deck plus comparison decks) don't share a datalist and cross-wire suggestions.
+  const listId = useId()
+
+  const addTag = (raw) => {
+    const t = raw.trim()
+    if (!t || current.includes(t)) {
+      setText("")
+      return
+    }
+    onChange([...current, t])
+    setText("")
+  }
+
+  const removeTag = (t) => {
+    onChange(current.filter((x) => x !== t))
+  }
+
+  const onKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      addTag(text)
+    } else if (e.key === "Tab" && text.trim() !== "") {
+      // Complete the current tag but keep focus here so the user can keep adding.
+      e.preventDefault()
+      addTag(text)
+    } else if (e.key === "Backspace" && text === "" && current.length > 0) {
+      removeTag(current[current.length - 1])
+    }
+  }
+
+  return (
+    <div className="tag-editor" style={{"display": "flex", "flexWrap": "wrap", "alignItems": "center", "gap": "0.25rem"}}>
+      {current.map((t) => (
+        <span key={t} className="tag-pill" style={{"display": "inline-flex", "alignItems": "center", "gap": "0.25rem", "padding": "0.1rem 0.4rem", "borderRadius": "0.75rem", "background": "var(--border)"}}>
+          {t}
+          <button type="button" onClick={() => removeTag(t)} style={{"border": "none", "background": "none", "cursor": "pointer", "color": "var(--primary)", "padding": "0", "lineHeight": "1"}} aria-label={`Remove ${t}`}>×</button>
+        </span>
+      ))}
+      <input
+        className="text-input"
+        list={listId}
+        value={text}
+        placeholder="Add tag…"
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={() => addTag(text)}
+        style={{"minWidth": "6rem", "flex": "1"}}
+      />
+      <datalist id={listId}>
+        {(suggestions || []).map((s) => <option key={s} value={s} />)}
+      </datalist>
+    </div>
+  )
+}

--- a/ui/src/pages/DeckViewer.js
+++ b/ui/src/pages/DeckViewer.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { LoadCube, LoadDecks, FetchNotes, SaveNotes } from "../utils/Fetch.js"
+import { LoadCube, LoadDecks, FetchNotes, SaveNotes, SaveDeckMeta } from "../utils/Fetch.js"
 import { useCube } from "../contexts/CubeContext.js"
 import { Record, MatchRecord, Wins, Losses, Draws, MatchWins, MatchLosses, MatchDraws, InDeckColor } from "../utils/Deck.js"
 import { RemovalMatches, CounterspellMatches } from "../pages/Decks.js"
@@ -8,6 +8,7 @@ import { CardMatches, DeckMatches } from "../utils/Query.js"
 import { ColorImages } from "../utils/Colors.js"
 import { Button, TextInput, DropdownHeader, NumericInput, Checkbox, DateSelector } from "../components/Dropdown.js"
 import { PillSearchInput } from "../components/PillSearchInput.js"
+import { TagEditor } from "../components/TagEditor.js"
 import { InitialDates } from "../components/StatsUI.js"
 import { ColorPickerHeader } from "./Types.js"
 import ReactMarkdown from "react-markdown";
@@ -91,6 +92,16 @@ export function DeckViewer(props) {
       }
     }
     setDraftDropdownOptions(draftOpts)
+  }
+
+  // Merge a server-updated deck back into both the list and the selected deck.
+  function onDeckUpdated(updated) {
+    const match = (d) =>
+      d.player === updated.player &&
+      d.metadata && d.metadata.draft_id === updated.metadata.draft_id
+    // Replace the one deck that matches with the updated version, leave every other deck as-is.
+    setDecks((prev) => prev.map((d) => (match(d) ? updated : d)))
+    setDeck((prev) => (prev && match(prev) ? updated : prev))
   }
 
   function onDeckClicked(event) {
@@ -371,6 +382,8 @@ export function DeckViewer(props) {
             description={description}
             onDescriptionFetched={onDescriptionFetched}
             viewMode={viewMode}
+            archetypes={archetypes}
+            onDeckUpdated={onDeckUpdated}
           />
         </div>
       </div>
@@ -859,6 +872,40 @@ function DeckReport(input) {
 
 function PlayerFrame(input) {
   let deck = input.deck
+  const cube = input.cube
+  const onDeckUpdated = input.onDeckUpdated
+  const [saveError, setSaveError] = useState(null)
+
+  // Build the WUBRG checkbox array from the deck's effective colors.
+  const colorBools = ["W", "U", "B", "R", "G"].map((c) => (deck.colors || []).includes(c))
+  const hasOverride = !!(deck.colors_override && deck.colors_override.length)
+
+  // Commit a change to one of the three editable fields. Omitting a field keeps
+  // its current value; pass [] for colors to clear the override.
+  const commit = async ({ macro, labels, colors }) => {
+    setSaveError(null)
+    try {
+      const updated = await SaveDeckMeta(cube, {
+        draft_id: deck.metadata.draft_id,
+        player: deck.player,
+        macro_archetype: macro !== undefined ? macro : (deck.macro_archetype || ""),
+        labels: labels !== undefined ? labels : (deck.labels || []),
+        colors: colors !== undefined ? colors : (deck.colors_override || []),
+      })
+      if (onDeckUpdated) onDeckUpdated(updated)
+    } catch (e) {
+      setSaveError("Failed to save")
+    }
+  }
+
+  const onColorChecked = (e) => {
+    const idx = ["W", "U", "B", "R", "G"].indexOf(e.target.id)
+    if (idx < 0) return
+    const next = colorBools.slice()
+    next[idx] = !next[idx]
+    commit({ colors: CheckboxesToColors(next) })
+  }
+
   let cards = deck.mainboard
   if (input.mbsb == "Sideboard") {
     cards = deck.sideboard
@@ -928,7 +975,25 @@ function PlayerFrame(input) {
           <h2 style={{"margin": "0", "color": "var(--primary)"}}>{deck.player}</h2>
           <Button text="Copy to Clipboard" onClick={copyToClipboard} />
         </div>
-        <div style={{"fontSize": "1.2rem"}}>{colors}</div>
+        <OverlayTrigger
+          trigger="click"
+          rootClose
+          placement="bottom-end"
+          overlay={
+            <Popover id={`color-picker-${deck.player}`} style={{maxWidth: "none"}}>
+              <Popover.Body style={{padding: "0.25rem"}}>
+                <ColorPickerHeader display={colorBools} onChecked={onColorChecked} />
+                {!hasOverride && <div style={{"textAlign": "center", "fontSize": "0.8rem", "opacity": "0.7"}}>(inferred)</div>}
+                {saveError && <div style={{"textAlign": "center", "color": "var(--danger, red)", "fontSize": "0.8rem"}}>{saveError}</div>}
+              </Popover.Body>
+            </Popover>
+          }
+        >
+          <div style={{"fontSize": "1.2rem", "cursor": "pointer", "display": "flex", "alignItems": "center", "gap": "0.25rem"}} title="Edit colors">
+            {colors}
+            <span style={{"fontSize": "0.7rem", "opacity": "0.6"}}>▾</span>
+          </div>
+        </OverlayTrigger>
       </div>
 
       <div className="stats-grid" style={{"display": "grid", "gridTemplateColumns": "repeat(auto-fit, minmax(200px, 1fr))", "gap": "1rem"}}>
@@ -938,11 +1003,25 @@ function PlayerFrame(input) {
         </div>
         <div className="stat-item">
           <span className="player-frame-title">Archetype:</span>
-          <span className="player-frame-value">{getMacro(deck)}</span>
+          <DropdownHeader
+            value={deck.macro_archetype || ""}
+            options={[
+              { label: "—", value: "" },
+              { label: "Aggro", value: "aggro" },
+              { label: "Midrange", value: "midrange" },
+              { label: "Tempo", value: "tempo" },
+              { label: "Control", value: "control" },
+            ]}
+            onChange={(e) => commit({ macro: e.target.value })}
+          />
         </div>
         <div className="stat-item">
           <span className="player-frame-title">Tags:</span>
-          <span className="player-frame-value">{labels || "—"}</span>
+          <TagEditor
+            tags={deck.labels || []}
+            suggestions={input.archetypes || []}
+            onChange={(next) => commit({ labels: next })}
+          />
         </div>
         <div className="stat-item">
           <span className="player-frame-title">Event:</span>

--- a/ui/src/utils/Fetch.js
+++ b/ui/src/utils/Fetch.js
@@ -11,20 +11,28 @@ export async function LoadCube(cube, onFetch) {
   return c
 }
 
+// decorateDeck applies the client-side derived fields the UI expects on every
+// deck. colors_override preserves the raw server override (absent when the deck
+// uses inferred colors) because ExtractColors below overwrites d.colors with the
+// effective color list.
+export function decorateDeck(d) {
+  d.avg_cmc = AverageCMC({deck: d})
+  d.avg_word_count = AverageWordCount({deck: d})
+  d.colors_override = (d.colors && d.colors.length) ? d.colors : null
+  d.colors = ExtractColors({deck: d})
+  if (d.matches === null) {
+    d.matches = []
+  }
+  return d
+}
+
 export async function LoadDecks(cube, onLoad, start, end, draftSize, playerMatch, match, board) {
   const resp = await fetch(`/api/${cube}/decks?start=${start}&end=${end}&size=${draftSize}&player=${playerMatch}&match=${encodeURIComponent(match || "")}&board=${encodeURIComponent(board || "")}`);
   let decks = await resp.json();
 
   // TODO: Move this into the server code, instead of iterate decks here.
   for (let d of decks.decks) {
-    d.avg_cmc = AverageCMC({deck: d})
-    d.avg_word_count = AverageWordCount({deck: d})
-    d.colors = ExtractColors({deck: d})
-
-    // Avoid nil errors.
-    if (d.matches === null) {
-      d.matches = []
-    }
+    decorateDeck(d)
   }
 
   onLoad(decks.decks)
@@ -100,6 +108,23 @@ export async function SaveNotes(cube, path, content) {
   if (!resp.ok) {
     throw new Error("Failed to save notes");
   }
+}
+
+// SaveDeckMeta writes the three editable metadata fields for a deck identified
+// by (draft_id, player) and returns the updated, decorated deck.
+export async function SaveDeckMeta(cube, { draft_id, player, macro_archetype, labels, colors }) {
+  const resp = await fetch(`/api/${cube}/decks/update`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ draft_id, player, macro_archetype, labels, colors }),
+  });
+  if (!resp.ok) {
+    throw new Error("Failed to save deck metadata");
+  }
+  let d = await resp.json();
+  return decorateDeck(d);
 }
 
 // FetchIndex loads the draft index file from the server.


### PR DESCRIPTION
Adds the UI for editing a deck's archetype, tags, and colors, wired to the deck update endpoint.