### PR TITLE
Add pkg/ocr with bounding-box helpers and detect options

### DIFF
--- a/pkg/ocr/bbox.go
+++ b/pkg/ocr/bbox.go
@@ -1,0 +1,46 @@
+package ocr
+
+// Bbox is an axis-aligned bounding box in image coordinates.
+type Bbox struct {
+	X      int
+	Y      int
+	Width  int
+	Height int
+}
+
+// overlapFraction returns the intersection area of a and b divided by a's area.
+// Returns 0 if a has zero area or there is no overlap.
+func overlapFraction(a, b Bbox) float64 {
+	aArea := a.Width * a.Height
+	if aArea <= 0 {
+		return 0
+	}
+	x1 := max(a.X, b.X)
+	y1 := max(a.Y, b.Y)
+	x2 := min(a.X+a.Width, b.X+b.Width)
+	y2 := min(a.Y+a.Height, b.Y+b.Height)
+	if x2 <= x1 || y2 <= y1 {
+		return 0
+	}
+	return float64((x2-x1)*(y2-y1)) / float64(aArea)
+}
+
+// bboxIntersectionOverUnion returns the intersection over union of a and b.
+// Returns 0 if either has zero area or there is no overlap.
+func bboxIntersectionOverUnion(a, b Bbox) float64 {
+	aArea := a.Width * a.Height
+	bArea := b.Width * b.Height
+	if aArea <= 0 || bArea <= 0 {
+		return 0
+	}
+	x1 := max(a.X, b.X)
+	y1 := max(a.Y, b.Y)
+	x2 := min(a.X+a.Width, b.X+b.Width)
+	y2 := min(a.Y+a.Height, b.Y+b.Height)
+	if x2 <= x1 || y2 <= y1 {
+		return 0
+	}
+	inter := (x2 - x1) * (y2 - y1)
+	union := aArea + bArea - inter
+	return float64(inter) / float64(union)
+}

--- a/pkg/ocr/bbox_test.go
+++ b/pkg/ocr/bbox_test.go
@@ -1,0 +1,55 @@
+package ocr
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverlapFraction_NoOverlap(t *testing.T) {
+	a := Bbox{X: 0, Y: 0, Width: 10, Height: 10}
+	b := Bbox{X: 100, Y: 100, Width: 10, Height: 10}
+	require.Equal(t, 0.0, overlapFraction(a, b))
+}
+
+func TestOverlapFraction_FullyContained(t *testing.T) {
+	a := Bbox{X: 0, Y: 0, Width: 10, Height: 10}
+	b := Bbox{X: -5, Y: -5, Width: 100, Height: 100}
+	require.Equal(t, 1.0, overlapFraction(a, b))
+}
+
+func TestOverlapFraction_HalfOverlap(t *testing.T) {
+	a := Bbox{X: 0, Y: 0, Width: 10, Height: 10}
+	b := Bbox{X: 5, Y: 0, Width: 10, Height: 10}
+	require.InDelta(t, 0.5, overlapFraction(a, b), 1e-9)
+}
+
+func TestOverlapFraction_ZeroAreaA(t *testing.T) {
+	a := Bbox{X: 0, Y: 0, Width: 0, Height: 10}
+	b := Bbox{X: 0, Y: 0, Width: 10, Height: 10}
+	require.Equal(t, 0.0, overlapFraction(a, b))
+}
+
+func TestBboxIntersectionOverUnion(t *testing.T) {
+	cases := []struct {
+		name string
+		a    Bbox
+		b    Bbox
+		want float64
+	}{
+		{"identical", Bbox{0, 0, 10, 10}, Bbox{0, 0, 10, 10}, 1.0},
+		{"disjoint", Bbox{0, 0, 10, 10}, Bbox{20, 20, 10, 10}, 0.0},
+		{"half-overlap-on-x", Bbox{0, 0, 10, 10}, Bbox{5, 0, 10, 10}, 50.0 / 150.0},
+		{"contained", Bbox{0, 0, 10, 10}, Bbox{2, 2, 4, 4}, 16.0 / 100.0},
+		{"a-zero-area", Bbox{0, 0, 0, 10}, Bbox{0, 0, 10, 10}, 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bboxIntersectionOverUnion(tc.a, tc.b)
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Fatalf("bboxIntersectionOverUnion(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/ocr/detect_options.go
+++ b/pkg/ocr/detect_options.go
@@ -1,0 +1,21 @@
+package ocr
+
+// DetectOptions holds tunables for the OCR pipeline.
+type DetectOptions struct {
+	// RotateDegrees rotates the image clockwise by 0, 90, 180, or 270 degrees
+	// before processing. Other values are rejected.
+	RotateDegrees int
+
+	// KeepCardCrops, if true, persists each per-card image and exposes its
+	// path on the corresponding MatchResult.
+	KeepCardCrops bool
+
+	// SleeveColor names a preset sleeve color (e.g. "orange") used to look up
+	// the HSV hue range. Ignored if SleeveHueRange is set explicitly.
+	SleeveColor string
+
+	// SleeveHueRange is the inclusive [hueLo, hueHi] window (OpenCV 0-179)
+	// used to build the sleeve mask. If both bounds are zero the pipeline
+	// falls back to SleeveColor or auto-detection.
+	SleeveHueRange [2]int
+}


### PR DESCRIPTION
Adds the pkg/ocr package with bounding-box overlap helpers and the DetectOptions struct.