### PR TITLE
Add sleeve color segmentation behind ocr_cv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,14 @@ bin/server: $(GO_FILES)
 	mkdir -p bin
 	CGO_ENABLED=0 go build -o bin/server ./cmd/server/server.go
 
+# Native server with OCR support (requires OpenCV + tesseract installed locally).
+bin/server-ocr: $(GO_FILES)
+	mkdir -p bin
+	CGO_ENABLED=1 go build -tags ocr_cv -o bin/server-ocr ./cmd/server/server.go
+
+run-server-native: bin/server-ocr
+	./bin/server-ocr
+
 server: .server.created
 .server.created: $(shell find pkg -name "*.go") bin/server Dockerfile.server
 	docker build -t caseydavenport/cube-tools-server -f Dockerfile.server .

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
+	gocv.io/x/gocv v0.31.0
 	gonum.org/v1/gonum v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e/go.mod h1:eagM805MRKrioHYuU7iKLUyFPVKqVV6um5DAvCkUtXs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -25,6 +27,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gocv.io/x/gocv v0.31.0 h1:BHDtK8v+YPvoSPQTTiZB2fM/7BLg6511JqkruY2z6LQ=
+gocv.io/x/gocv v0.31.0/go.mod h1:oc6FvfYqfBp99p+yOEzs9tbYF9gOrAQSeL/dyIPefJU=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/pkg/ocr/sleeve.go
+++ b/pkg/ocr/sleeve.go
@@ -1,0 +1,122 @@
+//go:build ocr_cv
+
+package ocr
+
+import (
+	"image"
+	"image/color"
+
+	"gocv.io/x/gocv"
+)
+
+// Sleeve-segmentation tuning constants.
+//
+// We work in HSV color space (hue, saturation, value) instead of RGB. Hue is
+// the color itself, kept separate from how bright or washed-out the pixel is,
+// so we can pick out "orange" without lighting throwing us off. OpenCV packs
+// hue into 0-179 (half the usual 0-360 degrees, so it fits in one byte).
+const (
+	// Low and high ends of the orange hue band. Every cube we handle uses
+	// orange sleeves.
+	SleeveHueLo = 5
+	SleeveHueHi = 22
+
+	// A pixel only counts as sleeve if it's at least this saturated (vivid,
+	// not grey) and this bright. Drops washed-out and shadowed pixels.
+	SleeveSatMin = 120
+	SleeveValMin = 100
+
+	// Kernel sizes (in pixels) for the cleanup at the end. "Close" fills small
+	// holes inside the mask; "dilate" grows the mask outward a little.
+	SealCloseKernel  = 5
+	SealDilateKernel = 3
+	SealDilateIter   = 1
+
+	// Glossy sleeves catch glare: bright spots that wash out to near-white and
+	// fall outside the orange band, punching holes in the mask. This is the
+	// near-white band we treat as possible glare: high brightness (value), low
+	// saturation (close to white).
+	GlareValMin = 220
+	GlareSatMax = 60
+
+	// We only trust a near-white pixel as glare if it sits just above real
+	// orange (glare runs along the top edge, since light comes from above).
+	// GlareVicinity is how far up to look (px); GlareVicinityHalfWidth is a
+	// little sideways slack.
+	GlareVicinity          = 40
+	GlareVicinityHalfWidth = 6
+)
+
+// BuildSleeveMask finds the orange sleeves and returns a mask: a black-and-white
+// image (one byte per pixel, which OpenCV calls CV_8UC1) that's white where the
+// pixel looks like sleeve and black everywhere else.
+//
+// It keeps the pixels in the orange band, adds back glare that washed out of
+// that band, then cleans up the result with morphology (fills small holes and
+// grows the shape) to seal gaps. The caller is responsible for freeing the
+// returned Mat by calling Close on it.
+func BuildSleeveMask(img gocv.Mat) gocv.Mat {
+	hsv := gocv.NewMat()
+	defer hsv.Close()
+	gocv.CvtColor(img, &hsv, gocv.ColorBGRToHSV)
+
+	// Keep pixels inside the orange band that are vivid and bright enough.
+	raw := gocv.NewMat()
+	defer raw.Close()
+	lower := gocv.NewScalar(SleeveHueLo, SleeveSatMin, SleeveValMin, 0)
+	upper := gocv.NewScalar(SleeveHueHi, 255, 255, 0)
+	gocv.InRangeWithScalar(hsv, lower, upper, &raw)
+
+	// Find every near-white pixel (bright, low saturation). On its own this
+	// catches glare plus any other white in the photo; we narrow it down below
+	// to just the bits sitting on or above real orange.
+	highlight := gocv.NewMat()
+	defer highlight.Close()
+	hiLo := gocv.NewScalar(0, 0, GlareValMin, 0)
+	hiHi := gocv.NewScalar(179, GlareSatMax, 255, 0)
+	gocv.InRangeWithScalar(hsv, hiLo, hiHi, &highlight)
+
+	// Grow the orange mask into a "vicinity" mask covering the strip just above
+	// each sleeve pixel. The kernel (the brush shape the grow uses) is tall and
+	// narrow, and we anchor it at its bottom edge so it paints upward, where
+	// glare lives, not downward into card-front reflection.
+	kW := 2*GlareVicinityHalfWidth + 1
+	kH := GlareVicinity + 1
+	vicinityKernel := gocv.GetStructuringElement(gocv.MorphRect, image.Pt(kW, kH))
+	defer vicinityKernel.Close()
+	vicinity := gocv.NewMat()
+	defer vicinity.Close()
+	gocv.DilateWithParams(raw, &vicinity, vicinityKernel,
+		image.Pt(GlareVicinityHalfWidth, kH-1), 1,
+		gocv.BorderConstant, color.RGBA{0, 0, 0, 0})
+
+	// Glare is the near-white pixels that fall inside that vicinity; OR it back
+	// into the orange mask.
+	glare := gocv.NewMat()
+	defer glare.Close()
+	gocv.BitwiseAnd(highlight, vicinity, &glare)
+
+	merged := gocv.NewMat()
+	defer merged.Close()
+	gocv.BitwiseOr(raw, glare, &merged)
+
+	// Fill small holes, then grow the mask outward to seal remaining gaps.
+	closeKernel := gocv.GetStructuringElement(gocv.MorphRect, image.Pt(SealCloseKernel, SealCloseKernel))
+	defer closeKernel.Close()
+	closed := gocv.NewMat()
+	defer closed.Close()
+	gocv.MorphologyEx(merged, &closed, gocv.MorphClose, closeKernel)
+
+	dilateKernel := gocv.GetStructuringElement(gocv.MorphRect, image.Pt(SealDilateKernel, SealDilateKernel))
+	defer dilateKernel.Close()
+
+	out := gocv.NewMat()
+	gocv.Dilate(closed, &out, dilateKernel)
+	for i := 1; i < SealDilateIter; i++ {
+		next := gocv.NewMat()
+		gocv.Dilate(out, &next, dilateKernel)
+		out.Close()
+		out = next
+	}
+	return out
+}


### PR DESCRIPTION
Adds the orange HSV sleeve-segmentation mask (with specular-glare recovery) behind the ocr_cv build tag, pulling in gocv v0.31.0 (OpenCV 4.6) and a native bin/server-ocr build target. Orange is the only sleeve color we use, so the multi-color presets and the flaky auto-hue detector are left out.