### PR TITLE
server: add OCR Detector and API types

### DIFF
--- a/pkg/server/ocr/detector.go
+++ b/pkg/server/ocr/detector.go
@@ -1,0 +1,60 @@
+package ocr
+
+import (
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+// Detector runs the OCR pipeline. The production implementation requires a
+// binary built with `-tags ocr_cv`; without it the underlying calls return an
+// error explaining how to rebuild.
+type Detector interface {
+	DetectPhoto(imagePath string, cube *types.Cube) ([]ocrpkg.MatchResult, error)
+	MatchRegion(imagePath string, box ocrpkg.Bbox, cube *types.Cube) (ocrpkg.MatchResult, error)
+}
+
+type pipelineDetector struct{}
+
+func NewDetector() Detector { return pipelineDetector{} }
+
+func (pipelineDetector) DetectPhoto(imagePath string, cube *types.Cube) ([]ocrpkg.MatchResult, error) {
+	return ocrpkg.DetectAndMatch(imagePath, cube, ocrpkg.DetectOptions{})
+}
+
+func (pipelineDetector) MatchRegion(imagePath string, box ocrpkg.Bbox, cube *types.Cube) (ocrpkg.MatchResult, error) {
+	return ocrpkg.MatchRegion(imagePath, box, cube, ocrpkg.DetectOptions{})
+}
+
+type LineJSON struct {
+	DetectedText string             `json:"detected_text"`
+	Bbox         ocrpkg.Bbox        `json:"bbox"`
+	Band         string             `json:"confidence_band"`
+	Chosen       string             `json:"chosen,omitempty"`
+	Candidates   []ocrpkg.Candidate `json:"candidates,omitempty"`
+}
+
+func toLineJSON(r ocrpkg.MatchResult) LineJSON {
+	jl := LineJSON{
+		DetectedText: r.DetectedText,
+		Bbox:         r.Bbox,
+		Band:         bandString(r.Band),
+		Candidates:   r.Candidates,
+	}
+	if r.Band != ocrpkg.ConfidenceUnmatched && len(r.Candidates) > 0 {
+		jl.Chosen = r.Candidates[0].Name
+	}
+	return jl
+}
+
+func bandString(b ocrpkg.Confidence) string {
+	switch b {
+	case ocrpkg.ConfidenceHigh:
+		return "high"
+	case ocrpkg.ConfidenceLow:
+		return "low"
+	case ocrpkg.ConfidenceVeryLow:
+		return "very_low"
+	default:
+		return "unmatched"
+	}
+}

--- a/pkg/server/ocr/detector_test.go
+++ b/pkg/server/ocr/detector_test.go
@@ -1,0 +1,33 @@
+package ocr
+
+import (
+	"testing"
+
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+)
+
+func TestToLineJSON(t *testing.T) {
+	r := ocrpkg.MatchResult{
+		DetectedText: "Counterspel",
+		Bbox:         ocrpkg.Bbox{X: 1, Y: 2, Width: 3, Height: 4},
+		Band:         ocrpkg.ConfidenceHigh,
+		Candidates:   []ocrpkg.Candidate{{Name: "Counterspell", Score: 0.95}, {Name: "Counterflux", Score: 0.5}},
+	}
+	got := toLineJSON(r)
+	if got.Band != "high" {
+		t.Fatalf("band = %q, want high", got.Band)
+	}
+	if got.Chosen != "Counterspell" {
+		t.Fatalf("chosen = %q, want Counterspell", got.Chosen)
+	}
+	if len(got.Candidates) != 2 {
+		t.Fatalf("candidates = %d, want 2", len(got.Candidates))
+	}
+}
+
+func TestToLineJSONUnmatchedHasNoChosen(t *testing.T) {
+	got := toLineJSON(ocrpkg.MatchResult{Band: ocrpkg.ConfidenceUnmatched})
+	if got.Chosen != "" {
+		t.Fatalf("chosen = %q, want empty for unmatched", got.Chosen)
+	}
+}

--- a/pkg/server/ocr/types.go
+++ b/pkg/server/ocr/types.go
@@ -1,0 +1,59 @@
+package ocr
+
+import "github.com/caseydavenport/cube-tools/pkg/types"
+
+type PhotoSet struct {
+	Checkin  []string `json:"checkin"`
+	Checkout []string `json:"checkout"`
+	Deck     []string `json:"deck"`
+}
+
+type PlayerDetail struct {
+	ID      string        `json:"id"`
+	Photos  PhotoSet      `json:"photos"`
+	Matches []types.Match `json:"matches"`
+	HasDeck bool          `json:"has_deck"`
+
+	// Status is the progress indicator for the player list:
+	// "done" (deck confirmed), "in_progress" (OCR work saved), or "unstarted".
+	Status string `json:"status"`
+
+	// NeedsReconfirm is set when a confirmed deck is stale: the live session
+	// pool no longer matches what was written, so the deck should be rebuilt.
+	NeedsReconfirm bool `json:"needs_reconfirm"`
+
+	// Warnings are cross-check problems with a confirmed deck (pool/mainboard
+	// sizes, cards in the deck but not the pool), mirroring the workspace checks.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+type DraftDetail struct {
+	DraftID   string         `json:"draft_id"`
+	EventName string         `json:"event_name"`
+	Flight    string         `json:"flight,omitempty"`
+	Players   []PlayerDetail `json:"players"`
+}
+
+type DraftSummary struct {
+	DraftID   string `json:"draft_id"`
+	EventName string `json:"event_name"`
+	Flight    string `json:"flight,omitempty"`
+	Players   int    `json:"players"`
+	Confirmed int    `json:"confirmed"`
+
+	// Conflicts is the number of over-count/unknown discrepancies from the
+	// pool-vs-cube check, surfaced as a warning badge on the draft list.
+	Conflicts int `json:"conflicts"`
+
+	// ReconfirmNeeded counts confirmed players whose deck is stale, and Warnings
+	// counts confirmed players with cross-check problems. Both drive draft-list
+	// badges so a draft's trouble is visible without opening it.
+	ReconfirmNeeded int `json:"reconfirm_needed"`
+	Warnings        int `json:"warnings"`
+}
+
+type CardInfo struct {
+	Name      string `json:"name"`
+	MaxCopies int    `json:"max_copies"`
+	IsLand    bool   `json:"is_land"`
+}


### PR DESCRIPTION
Starts Phase 3 (the OCR server) with a new `pkg/server/ocr` package: the API response types and a `Detector` interface wrapping `DetectAndMatch`/`MatchRegion`, so handlers depend on the interface rather than gocv directly. Pure-Go (uses the stub without `ocr_cv`); tested-but-unused until the handlers land.