### PR TITLE
server: add OCR session store and handlers

### DIFF
--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -11,6 +11,12 @@ type ctxKey int
 
 const cubeKey ctxKey = 0
 
+// ContextWithCube returns ctx with the cube id attached, the same way WithCube
+// does. Exported for handlers in subpackages and for tests.
+func ContextWithCube(ctx context.Context, cube string) context.Context {
+	return context.WithValue(ctx, cubeKey, cube)
+}
+
 // WithCube validates the {cube} path param against the registry and stashes the
 // cube ID in the request context. Handlers retrieve it via CubeFromRequest.
 func WithCube(reg *cubes.Registry, h http.Handler) http.Handler {
@@ -20,7 +26,7 @@ func WithCube(reg *cubes.Registry, h http.Handler) http.Handler {
 			http.NotFound(rw, r)
 			return
 		}
-		ctx := context.WithValue(r.Context(), cubeKey, id)
+		ctx := ContextWithCube(r.Context(), id)
 		h.ServeHTTP(rw, r.WithContext(ctx))
 	})
 }

--- a/pkg/server/ocr/session.go
+++ b/pkg/server/ocr/session.go
@@ -1,0 +1,91 @@
+package ocr
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+)
+
+const sessionFileName = ".ocr-session.json"
+
+type Session struct {
+	DraftID string                 `json:"draft_id"`
+	Players map[string]*PlayerWork `json:"players"`
+}
+
+type PlayerWork struct {
+	Status string `json:"status"`
+
+	// Boxes are the editable source of truth for a player's work: per-photo
+	// OCR regions (detected or hand-drawn). The pool and mainboard lists are
+	// derived from these on the client, so persisting them lets a reload
+	// resume exactly where the user left off without re-running OCR.
+	Boxes     map[string][]Box `json:"boxes,omitempty"`      // pool photo -> boxes
+	DeckBoxes map[string][]Box `json:"deck_boxes,omitempty"` // deck photo -> boxes
+	Bonus     map[string]int   `json:"bonus,omitempty"`      // manual pool count deltas
+	DeckBonus map[string]int   `json:"deck_bonus,omitempty"` // manual mainboard count deltas
+	Basics    map[string]int   `json:"basics,omitempty"`
+
+	// PoolEntries/MainboardEntries are the derived lists at last save, kept so
+	// the draft list can report progress without replaying the client logic.
+	PoolEntries      []PoolEntry `json:"pool_entries,omitempty"`
+	MainboardEntries []PoolEntry `json:"mainboard_entries,omitempty"`
+}
+
+// Box is one OCR region on a photo. Status is the confidence band
+// ("high"/"low"/"very_low"/"unmatched") or "pending" while OCR runs.
+type Box struct {
+	ID         string             `json:"id"`
+	Bbox       ocrpkg.Bbox        `json:"bbox"`
+	Status     string             `json:"status"`
+	Chosen     string             `json:"chosen,omitempty"`
+	Candidates []ocrpkg.Candidate `json:"candidates,omitempty"`
+}
+
+type PoolEntry struct {
+	CardName   string             `json:"card_name"`
+	Count      int                `json:"count"`
+	Source     Source             `json:"source"`
+	Candidates []ocrpkg.Candidate `json:"candidates,omitempty"`
+}
+
+type Source struct {
+	Photo string      `json:"photo"`
+	Box   ocrpkg.Bbox `json:"box"`
+}
+
+// LoadSession reads the working session for a draft. A missing file yields an
+// empty session, not an error.
+func LoadSession(dataRoot, cube, draftID string) (*Session, error) {
+	path := filepath.Join(dataRoot, cube, draftID, sessionFileName)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &Session{DraftID: draftID, Players: map[string]*PlayerWork{}}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var s Session
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	if s.Players == nil {
+		s.Players = map[string]*PlayerWork{}
+	}
+	return &s, nil
+}
+
+// Save writes the session to data/<cube>/<draftID>/.ocr-session.json.
+func (s *Session) Save(dataRoot, cube string) error {
+	path := filepath.Join(dataRoot, cube, s.DraftID, sessionFileName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", " ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/pkg/server/ocr/session_handlers.go
+++ b/pkg/server/ocr/session_handlers.go
@@ -1,0 +1,71 @@
+package ocr
+
+import (
+	"encoding/json"
+	"maps"
+	"net/http"
+	"sync"
+
+	"github.com/caseydavenport/cube-tools/pkg/server"
+)
+
+// sessionSaveMu serializes the load-merge-write in SessionSaveHandler. The
+// client autosaves one player at a time, so concurrent saves for different
+// players would otherwise race on the shared session file and lose work.
+var sessionSaveMu sync.Mutex
+
+func SessionGetHandler() http.Handler { return SessionGetHandlerWithRoot("data") }
+
+func SessionGetHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		draftID := r.PathValue("draft_id")
+		if cube == "" || !validDraftID(draftID) {
+			http.NotFound(rw, r)
+			return
+		}
+		s, err := LoadSession(dataRoot, cube, draftID)
+		if err != nil {
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(rw, s)
+	})
+}
+
+func SessionSaveHandler() http.Handler { return SessionSaveHandlerWithRoot("data") }
+
+func SessionSaveHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		draftID := r.PathValue("draft_id")
+		if cube == "" || !validDraftID(draftID) {
+			http.NotFound(rw, r)
+			return
+		}
+		var posted Session
+		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+			http.Error(rw, "Invalid request", http.StatusBadRequest)
+			return
+		}
+
+		sessionSaveMu.Lock()
+		defer sessionSaveMu.Unlock()
+
+		// Merge the posted players into what's already on disk rather than
+		// replacing the file. The client sends only the player it's editing, so
+		// a full replace would wipe every other player's saved work.
+		s, err := LoadSession(dataRoot, cube, draftID)
+		if err != nil {
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		s.DraftID = draftID // trust the path, not the body
+		maps.Copy(s.Players, posted.Players)
+		if err := s.Save(dataRoot, cube); err != nil {
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		rw.WriteHeader(http.StatusOK)
+	})
+}

--- a/pkg/server/ocr/session_handlers_test.go
+++ b/pkg/server/ocr/session_handlers_test.go
@@ -1,0 +1,74 @@
+package ocr
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSessionSaveThenGet(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	if err := os.MkdirAll(filepath.Join(root, "polyverse", draftID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	save := SessionSaveHandlerWithRoot(root)
+	rs := reqWithCube(t, "POST", "/api/polyverse/ocr/drafts/"+draftID+"/session", "polyverse")
+	rs.SetPathValue("draft_id", draftID)
+	rs.Body = bodyOf(`{"draft_id":"` + draftID + `","players":{"p3":{"status":"in_progress","pool_entries":[{"card_name":"Brainstorm","count":1}],"basics":{},"photos_done":{}}}}`)
+	ws := httptest.NewRecorder()
+	save.ServeHTTP(ws, rs)
+	if ws.Code != 200 {
+		t.Fatalf("save status = %d body=%s", ws.Code, ws.Body.String())
+	}
+
+	get := SessionGetHandlerWithRoot(root)
+	rg := reqWithCube(t, "GET", "/api/polyverse/ocr/drafts/"+draftID+"/session", "polyverse")
+	rg.SetPathValue("draft_id", draftID)
+	wg := httptest.NewRecorder()
+	get.ServeHTTP(wg, rg)
+	if wg.Code != 200 {
+		t.Fatalf("get status = %d", wg.Code)
+	}
+	if !strings.Contains(wg.Body.String(), "Brainstorm") {
+		t.Fatalf("get body missing data: %s", wg.Body.String())
+	}
+}
+
+// Saving one player must not wipe another player's already-saved work: the
+// client autosaves a single player at a time, so the server merges by id.
+func TestSessionSaveMergesPlayers(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	if err := os.MkdirAll(filepath.Join(root, "polyverse", draftID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	save := SessionSaveHandlerWithRoot(root)
+
+	post := func(body string) {
+		rs := reqWithCube(t, "POST", "/api/polyverse/ocr/drafts/"+draftID+"/session", "polyverse")
+		rs.SetPathValue("draft_id", draftID)
+		rs.Body = bodyOf(body)
+		w := httptest.NewRecorder()
+		save.ServeHTTP(w, rs)
+		if w.Code != 200 {
+			t.Fatalf("save status = %d body=%s", w.Code, w.Body.String())
+		}
+	}
+	post(`{"players":{"p1":{"status":"in_progress","pool_entries":[{"card_name":"Brainstorm","count":1}]}}}`)
+	post(`{"players":{"p2":{"status":"in_progress","pool_entries":[{"card_name":"Ponder","count":1}]}}}`)
+
+	s, err := LoadSession(root, "polyverse", draftID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Players["p1"] == nil {
+		t.Fatalf("p1 was wiped by p2's save: %+v", s.Players)
+	}
+	if s.Players["p2"] == nil {
+		t.Fatalf("p2 missing: %+v", s.Players)
+	}
+}

--- a/pkg/server/ocr/session_test.go
+++ b/pkg/server/ocr/session_test.go
@@ -1,0 +1,87 @@
+package ocr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+)
+
+func TestSessionRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	if err := os.MkdirAll(filepath.Join(root, "polyverse", draftID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	photo := draftID + "/img/p3/checkin-1.jpg"
+	s := &Session{DraftID: draftID, Players: map[string]*PlayerWork{
+		"p3": {
+			Status: "in_progress",
+			Boxes: map[string][]Box{photo: {{
+				ID:     photo + ":0",
+				Bbox:   ocrpkg.Bbox{X: 1, Y: 2, Width: 3, Height: 4},
+				Status: "high",
+				Chosen: "Counterspell",
+			}}},
+			Bonus:  map[string]int{"Counterspell": 1},
+			Basics: map[string]int{"Island": 7},
+			PoolEntries: []PoolEntry{{
+				CardName: "Counterspell", Count: 1,
+				Source: Source{Photo: photo, Box: ocrpkg.Bbox{X: 1, Y: 2, Width: 3, Height: 4}},
+			}},
+		},
+	}}
+	if err := s.Save(root, "polyverse"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadSession(root, "polyverse", draftID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Players["p3"].Boxes[photo][0].Chosen != "Counterspell" {
+		t.Fatalf("round-trip lost box data: %+v", got.Players["p3"])
+	}
+	if got.Players["p3"].Bonus["Counterspell"] != 1 {
+		t.Fatalf("bonus lost: %+v", got.Players["p3"].Bonus)
+	}
+	if got.Players["p3"].Basics["Island"] != 7 {
+		t.Fatalf("basics lost: %+v", got.Players["p3"].Basics)
+	}
+}
+
+func TestLoadSessionMissingIsEmpty(t *testing.T) {
+	root := t.TempDir()
+	s, err := LoadSession(root, "polyverse", "2026-01-17_evt_1")
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if s == nil || len(s.Players) != 0 {
+		t.Fatalf("expected empty session, got %+v", s)
+	}
+}
+
+func TestSaveCreatesDirectory(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_2"
+
+	s := &Session{DraftID: draftID, Players: map[string]*PlayerWork{
+		"p1": {
+			Status: "in_progress",
+			Basics: map[string]int{"Plains": 3},
+		},
+	}}
+	if err := s.Save(root, "polyverse"); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	got, err := LoadSession(root, "polyverse", draftID)
+	if err != nil {
+		t.Fatalf("LoadSession failed: %v", err)
+	}
+	if got.Players["p1"].Basics["Plains"] != 3 {
+		t.Fatalf("basics lost: %+v", got.Players["p1"].Basics)
+	}
+}

--- a/pkg/server/ocr/util.go
+++ b/pkg/server/ocr/util.go
@@ -1,0 +1,23 @@
+package ocr
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// validDraftID rejects empty ids and anything that could escape the data dir
+// (path separators or "..") - draft ids land directly in filesystem paths.
+func validDraftID(id string) bool {
+	return id != "" && !strings.ContainsAny(id, `/\`) && !strings.Contains(id, "..")
+}
+
+// writeJSON encodes v as indented JSON to the response. Encode errors are
+// ignored: by the time encoding fails the status line is already sent, so
+// there's nothing useful left to tell the client.
+func writeJSON(rw http.ResponseWriter, v any) {
+	rw.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(rw)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}

--- a/pkg/server/ocr/util_test.go
+++ b/pkg/server/ocr/util_test.go
@@ -1,0 +1,24 @@
+package ocr
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/caseydavenport/cube-tools/pkg/server"
+)
+
+// reqWithCube builds a test request with the cube id attached the way the
+// WithCube middleware would, so handlers calling CubeFromRequest see it.
+func reqWithCube(t *testing.T, method, target, cube string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(method, target, nil)
+	// WithCube stores the id under an unexported key; in tests we go through
+	// the exported setter instead.
+	return r.WithContext(server.ContextWithCube(context.Background(), cube))
+}
+
+func bodyOf(s string) io.ReadCloser { return io.NopCloser(strings.NewReader(s)) }


### PR DESCRIPTION
Adds the per-draft OCR session store (load/save to .ocr-session.json) and the GET/POST handlers. Saves merge by player id so the client's per-player autosave doesn't wipe other players' work.