### PR TITLE
server: add OCR image, detect, and region handlers

### DIFF
--- a/pkg/server/ocr/detect_handlers.go
+++ b/pkg/server/ocr/detect_handlers.go
@@ -1,0 +1,100 @@
+package ocr
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+	"github.com/caseydavenport/cube-tools/pkg/server"
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+type detectRequest struct {
+	Photo string `json:"photo"`
+}
+
+type regionRequest struct {
+	Photo string      `json:"photo"`
+	Box   ocrpkg.Bbox `json:"box"`
+}
+
+// resolvePhoto validates the relative photo path and returns its absolute
+// on-disk path plus the cube loaded for the draft date in the path.
+func resolvePhoto(dataRoot, cube, rel string) (string, *types.Cube, bool) {
+	if cube == "" || rel == "" || strings.Contains(rel, "..") {
+		return "", nil, false
+	}
+	abs := filepath.Clean(filepath.Join(dataRoot, cube, rel))
+	prefix := filepath.Clean(filepath.Join(dataRoot, cube)) + string(filepath.Separator)
+	if !strings.HasPrefix(abs, prefix) {
+		return "", nil, false
+	}
+	// Draft date is the first 10 chars of the first path segment.
+	seg := strings.SplitN(rel, "/", 2)[0]
+	date := ""
+	if len(seg) >= 10 {
+		date = seg[:10]
+	}
+	cube2, err := types.LoadCubeList(types.LoadOptions{DataRoot: dataRoot, Cube: cube, Date: date})
+	if err != nil {
+		cube2, err = types.LoadCubeList(types.LoadOptions{DataRoot: dataRoot, Cube: cube})
+		if err != nil {
+			return "", nil, false
+		}
+	}
+	return abs, cube2, true
+}
+
+func DetectHandler(det Detector) http.Handler { return DetectHandlerWithRoot(det, "data") }
+
+func DetectHandlerWithRoot(det Detector, dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		var req detectRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(rw, "Invalid request", http.StatusBadRequest)
+			return
+		}
+		abs, cl, ok := resolvePhoto(dataRoot, cube, req.Photo)
+		if !ok {
+			http.Error(rw, "Invalid path", http.StatusForbidden)
+			return
+		}
+		results, err := det.DetectPhoto(abs, cl)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		lines := make([]LineJSON, 0, len(results))
+		for _, res := range results {
+			lines = append(lines, toLineJSON(res))
+		}
+		writeJSON(rw, map[string]any{"lines": lines})
+	})
+}
+
+func RegionHandler(det Detector) http.Handler { return RegionHandlerWithRoot(det, "data") }
+
+func RegionHandlerWithRoot(det Detector, dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		var req regionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(rw, "Invalid request", http.StatusBadRequest)
+			return
+		}
+		abs, cl, ok := resolvePhoto(dataRoot, cube, req.Photo)
+		if !ok {
+			http.Error(rw, "Invalid path", http.StatusForbidden)
+			return
+		}
+		res, err := det.MatchRegion(abs, req.Box, cl)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(rw, toLineJSON(res))
+	})
+}

--- a/pkg/server/ocr/detect_handlers_test.go
+++ b/pkg/server/ocr/detect_handlers_test.go
@@ -1,0 +1,82 @@
+package ocr
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+type fakeDetector struct {
+	gotPath string
+	gotBox  ocrpkg.Bbox
+}
+
+func (f *fakeDetector) DetectPhoto(p string, _ *types.Cube) ([]ocrpkg.MatchResult, error) {
+	f.gotPath = p
+	return []ocrpkg.MatchResult{{
+		DetectedText: "Brainstom", Band: ocrpkg.ConfidenceHigh,
+		Candidates: []ocrpkg.Candidate{{Name: "Brainstorm", Score: 0.92}},
+		Bbox:       ocrpkg.Bbox{X: 5, Y: 6, Width: 7, Height: 8},
+	}}, nil
+}
+
+func (f *fakeDetector) MatchRegion(p string, box ocrpkg.Bbox, _ *types.Cube) (ocrpkg.MatchResult, error) {
+	f.gotPath, f.gotBox = p, box
+	return ocrpkg.MatchResult{
+		DetectedText: "Island", Band: ocrpkg.ConfidenceHigh,
+		Candidates: []ocrpkg.Candidate{{Name: "Island", Score: 0.99}}, Bbox: box,
+	}, nil
+}
+
+func setupCube(t *testing.T, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "polyverse", "2026-01-17", "cube-snapshot.json"),
+		`{"cards":[{"name":"Brainstorm"},{"name":"Island"}]}`)
+}
+
+func TestDetectHandler(t *testing.T) {
+	root := t.TempDir()
+	setupCube(t, root)
+	rel := "2026-01-17_evt_1/img/p3/checkin-1.jpg"
+	writeFile(t, filepath.Join(root, "polyverse", rel), "x")
+
+	fd := &fakeDetector{}
+	h := DetectHandlerWithRoot(fd, root)
+	r := reqWithCube(t, "POST", "/api/polyverse/ocr/detect", "polyverse")
+	r.Body = bodyOf(`{"photo":"` + rel + `"}`)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.HasSuffix(fd.gotPath, rel) {
+		t.Fatalf("detector got path %q", fd.gotPath)
+	}
+	var out struct {
+		Lines []LineJSON `json:"lines"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Lines) != 1 || out.Lines[0].Chosen != "Brainstorm" {
+		t.Fatalf("lines = %+v", out.Lines)
+	}
+}
+
+func TestRegionHandlerRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	setupCube(t, root)
+	h := RegionHandlerWithRoot(&fakeDetector{}, root)
+	r := reqWithCube(t, "POST", "/api/polyverse/ocr/region", "polyverse")
+	r.Body = bodyOf(`{"photo":"../../etc/passwd","box":{"X":0,"Y":0,"Width":1,"Height":1}}`)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 403 {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}

--- a/pkg/server/ocr/images.go
+++ b/pkg/server/ocr/images.go
@@ -1,0 +1,45 @@
+package ocr
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/caseydavenport/cube-tools/pkg/server"
+	"github.com/sirupsen/logrus"
+)
+
+// ImageHandler serves draft photos from data/<cube>/<path>.
+func ImageHandler() http.Handler { return ImageHandlerWithRoot("data") }
+
+// ImageHandlerWithRoot is ImageHandler with an injectable data root for tests.
+func ImageHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		raw := r.PathValue("path")
+		cleanPath := filepath.Clean(filepath.Join(dataRoot, cube, raw))
+		prefix := filepath.Clean(filepath.Join(dataRoot, cube)) + string(filepath.Separator)
+		if cube == "" || raw == "" || strings.Contains(raw, "..") || !strings.HasPrefix(cleanPath, prefix) {
+			logrus.WithFields(logrus.Fields{"cube": cube, "path": raw}).Warn("Blocked invalid image path")
+			http.Error(rw, "Invalid path", http.StatusForbidden)
+			return
+		}
+		f, err := os.Open(cleanPath)
+		if err != nil {
+			http.NotFound(rw, r)
+			return
+		}
+		defer f.Close()
+		st, err := f.Stat()
+		if err != nil {
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		// Photos can be rotated in place, so force revalidation: the browser
+		// still gets a cheap 304 when the file is unchanged, but picks up a
+		// rotated file on the next load instead of serving a stale copy.
+		rw.Header().Set("Cache-Control", "no-cache")
+		http.ServeContent(rw, r, filepath.Base(cleanPath), st.ModTime(), f)
+	})
+}

--- a/pkg/server/ocr/images_test.go
+++ b/pkg/server/ocr/images_test.go
@@ -1,0 +1,45 @@
+package ocr
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImageHandlerServesFile(t *testing.T) {
+	root := t.TempDir()
+	rel := "2026-01-17_evt_1/img/p3/checkin-1.jpg"
+	full := filepath.Join(root, "polyverse", rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("JPEGDATA"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := ImageHandlerWithRoot(root)
+	r := reqWithCube(t, "GET", "/api/polyverse/img/"+rel, "polyverse")
+	r.SetPathValue("path", rel)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if w.Body.String() != "JPEGDATA" {
+		t.Fatalf("body = %q", w.Body.String())
+	}
+}
+
+func TestImageHandlerRejectsTraversal(t *testing.T) {
+	h := ImageHandlerWithRoot(t.TempDir())
+	r := reqWithCube(t, "GET", "/api/polyverse/img/../../etc/passwd", "polyverse")
+	r.SetPathValue("path", "../../etc/passwd")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}

--- a/pkg/server/ocr/util_test.go
+++ b/pkg/server/ocr/util_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -22,3 +24,14 @@ func reqWithCube(t *testing.T, method, target, cube string) *http.Request {
 }
 
 func bodyOf(s string) io.ReadCloser { return io.NopCloser(strings.NewReader(s)) }
+
+// writeFile creates path's parent dirs and writes body, failing the test on error.
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Serves draft photos (with traversal guards and no-cache for in-place rotation) and adds the detect/region OCR handlers that resolve a photo to its cube snapshot and run the Detector. Pulls writeFile into the shared util_test.go.