### PR TITLE
server: add OCR photo rotate handler

### DIFF
--- a/pkg/server/ocr/rotate.go
+++ b/pkg/server/ocr/rotate.go
@@ -1,0 +1,118 @@
+package ocr
+
+import (
+	"encoding/json"
+	"image"
+	"image/jpeg"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/caseydavenport/cube-tools/pkg/server"
+	"github.com/sirupsen/logrus"
+)
+
+type rotateRequest struct {
+	Photo string `json:"photo"`
+	Dir   string `json:"dir"` // "cw" or "ccw"
+}
+
+func RotateHandler() http.Handler { return RotateHandlerWithRoot("data") }
+
+// RotateHandlerWithRoot rotates a draft photo 90 degrees in place. Detection,
+// region-matching, and display all read the file from disk, so rotating the
+// file itself keeps every view consistent without threading orientation
+// through each endpoint.
+func RotateHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		var req rotateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(rw, "Invalid request", http.StatusBadRequest)
+			return
+		}
+		if req.Dir != "cw" && req.Dir != "ccw" {
+			http.Error(rw, "Invalid direction", http.StatusBadRequest)
+			return
+		}
+		abs, ok := safePhotoPath(dataRoot, cube, req.Photo)
+		if !ok {
+			logrus.WithFields(logrus.Fields{"cube": cube, "path": req.Photo}).Warn("Blocked invalid rotate path")
+			http.Error(rw, "Invalid path", http.StatusForbidden)
+			return
+		}
+		if err := rotateJPEGFile(abs, req.Dir == "cw"); err != nil {
+			logrus.WithError(err).WithField("photo", req.Photo).Warn("Rotate failed")
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		rw.WriteHeader(http.StatusOK)
+	})
+}
+
+// safePhotoPath validates that rel stays within data/<cube> and returns the
+// absolute on-disk path.
+func safePhotoPath(dataRoot, cube, rel string) (string, bool) {
+	if cube == "" || rel == "" || strings.Contains(rel, "..") {
+		return "", false
+	}
+	abs := filepath.Clean(filepath.Join(dataRoot, cube, rel))
+	prefix := filepath.Clean(filepath.Join(dataRoot, cube)) + string(filepath.Separator)
+	if !strings.HasPrefix(abs, prefix) {
+		return "", false
+	}
+	return abs, true
+}
+
+// rotateJPEGFile rotates a JPEG on disk 90 degrees and rewrites it. Re-encoding
+// drops any EXIF orientation tag, so the stored pixels are what both the
+// browser and the detector see (no silent EXIF rotation to disagree about).
+// Writes to a temp file then renames, so a failure can't leave a half-written
+// photo behind.
+func rotateJPEGFile(path string, cw bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	src, err := jpeg.Decode(f)
+	f.Close()
+	if err != nil {
+		return err
+	}
+	rotated := rotate90(src, cw)
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".rotate-*.jpg")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if err := jpeg.Encode(tmp, rotated, &jpeg.Options{Quality: 92}); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// rotate90 turns src 90 degrees, clockwise when cw is true.
+func rotate90(src image.Image, cw bool) image.Image {
+	b := src.Bounds()
+	w, h := b.Dx(), b.Dy()
+	dst := image.NewRGBA(image.Rect(0, 0, h, w))
+	for y := range h {
+		for x := range w {
+			c := src.At(b.Min.X+x, b.Min.Y+y)
+			if cw {
+				dst.Set(h-1-y, x, c)
+			} else {
+				dst.Set(y, w-1-x, c)
+			}
+		}
+	}
+	return dst
+}

--- a/pkg/server/ocr/rotate_test.go
+++ b/pkg/server/ocr/rotate_test.go
@@ -1,0 +1,112 @@
+package ocr
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTestJPEG writes a wxh image whose top half is red and bottom half white.
+// A large block survives JPEG compression (a single pixel would not), so a test
+// can reliably check where the red region lands after rotation.
+func writeTestJPEG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		c := color.RGBA{255, 255, 255, 255}
+		if y < h/2 {
+			c = color.RGBA{255, 0, 0, 255}
+		}
+		for x := range w {
+			img.Set(x, y, c)
+		}
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := jpeg.Encode(f, img, &jpeg.Options{Quality: 100}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func decodeJPEG(t *testing.T, path string) image.Image {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, err := jpeg.Decode(bytes.NewReader(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return img
+}
+
+// isRedish reports whether c reads as red. JPEG is lossy, so we test for a
+// dominant red channel rather than exact equality.
+func isRedish(c color.Color) bool {
+	r, g, b, _ := c.RGBA()
+	return r>>8 > 180 && g>>8 < 80 && b>>8 < 80
+}
+
+func TestRotateHandlerClockwise(t *testing.T) {
+	root := t.TempDir()
+	rel := "2026-01-17_evt_1/img/p3/deck-1.jpg"
+	full := filepath.Join(root, "polyverse", rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 40x20 image, top half red. A clockwise turn produces a 20x40 image with
+	// the red moved to the right half (the top edge rotates to the right edge).
+	writeTestJPEG(t, full, 40, 20)
+
+	h := RotateHandlerWithRoot(root)
+	r := reqWithCube(t, "POST", "/api/polyverse/ocr/rotate", "polyverse")
+	r.Body = bodyOf(`{"photo":"` + rel + `","dir":"cw"}`)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	out := decodeJPEG(t, full)
+	if out.Bounds().Dx() != 20 || out.Bounds().Dy() != 40 {
+		t.Fatalf("dims = %dx%d, want 20x40", out.Bounds().Dx(), out.Bounds().Dy())
+	}
+	// Right column should be red, left column white.
+	if !isRedish(out.At(18, 20)) {
+		t.Fatalf("right half not red after CW rotate; got %v", out.At(18, 20))
+	}
+	if isRedish(out.At(1, 20)) {
+		t.Fatalf("left half should be white after CW rotate; got %v", out.At(1, 20))
+	}
+}
+
+func TestRotateHandlerRejectsBadDir(t *testing.T) {
+	h := RotateHandlerWithRoot(t.TempDir())
+	r := reqWithCube(t, "POST", "/api/polyverse/ocr/rotate", "polyverse")
+	r.Body = bodyOf(`{"photo":"x/y.jpg","dir":"sideways"}`)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 400 {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestRotateHandlerRejectsTraversal(t *testing.T) {
+	h := RotateHandlerWithRoot(t.TempDir())
+	r := reqWithCube(t, "POST", "/api/polyverse/ocr/rotate", "polyverse")
+	r.Body = bodyOf(`{"photo":"../../etc/passwd","dir":"cw"}`)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 403 {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}


### PR DESCRIPTION
Rotates a draft photo 90 degrees in place. Re-encodes to drop EXIF orientation so the stored pixels are what both the browser and detector see, and writes via temp-file-then-rename so a failure can't leave a half-written photo.