### PR TITLE
server: name the rotate field Direction and use cw/ccw constants

### DIFF
--- a/pkg/server/ocr/rotate.go
+++ b/pkg/server/ocr/rotate.go
@@ -13,9 +13,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Rotation directions, as sent in the request and compared against below.
+const (
+	directionCW  = "cw"
+	directionCCW = "ccw"
+)
+
 type rotateRequest struct {
-	Photo string `json:"photo"`
-	Dir   string `json:"dir"` // "cw" or "ccw"
+	Photo     string `json:"photo"`
+	Direction string `json:"direction"`
 }
 
 func RotateHandler() http.Handler { return RotateHandlerWithRoot("data") }
@@ -32,7 +38,7 @@ func RotateHandlerWithRoot(dataRoot string) http.Handler {
 			http.Error(rw, "Invalid request", http.StatusBadRequest)
 			return
 		}
-		if req.Dir != "cw" && req.Dir != "ccw" {
+		if req.Direction != directionCW && req.Direction != directionCCW {
 			http.Error(rw, "Invalid direction", http.StatusBadRequest)
 			return
 		}
@@ -42,7 +48,7 @@ func RotateHandlerWithRoot(dataRoot string) http.Handler {
 			http.Error(rw, "Invalid path", http.StatusForbidden)
 			return
 		}
-		if err := rotateJPEGFile(abs, req.Dir == "cw"); err != nil {
+		if err := rotateJPEGFile(abs, req.Direction == directionCW); err != nil {
 			logrus.WithError(err).WithField("photo", req.Photo).Warn("Rotate failed")
 			http.Error(rw, "Internal server error", http.StatusInternalServerError)
 			return

--- a/pkg/server/ocr/rotate_test.go
+++ b/pkg/server/ocr/rotate_test.go
@@ -69,7 +69,7 @@ func TestRotateHandlerClockwise(t *testing.T) {
 
 	h := RotateHandlerWithRoot(root)
 	r := reqWithCube(t, "POST", "/api/polyverse/ocr/rotate", "polyverse")
-	r.Body = bodyOf(`{"photo":"` + rel + `","dir":"cw"}`)
+	r.Body = bodyOf(`{"photo":"` + rel + `","direction":"cw"}`)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, r)
 	if w.Code != 200 {
@@ -92,7 +92,7 @@ func TestRotateHandlerClockwise(t *testing.T) {
 func TestRotateHandlerRejectsBadDir(t *testing.T) {
 	h := RotateHandlerWithRoot(t.TempDir())
 	r := reqWithCube(t, "POST", "/api/polyverse/ocr/rotate", "polyverse")
-	r.Body = bodyOf(`{"photo":"x/y.jpg","dir":"sideways"}`)
+	r.Body = bodyOf(`{"photo":"x/y.jpg","direction":"sideways"}`)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, r)
 	if w.Code != 400 {
@@ -103,7 +103,7 @@ func TestRotateHandlerRejectsBadDir(t *testing.T) {
 func TestRotateHandlerRejectsTraversal(t *testing.T) {
 	h := RotateHandlerWithRoot(t.TempDir())
 	r := reqWithCube(t, "POST", "/api/polyverse/ocr/rotate", "polyverse")
-	r.Body = bodyOf(`{"photo":"../../etc/passwd","dir":"cw"}`)
+	r.Body = bodyOf(`{"photo":"../../etc/passwd","direction":"cw"}`)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, r)
 	if w.Code != 403 {


### PR DESCRIPTION
Follow-up to #26: renames the request field to Direction (json "direction") and replaces the bare "cw"/"ccw" string literals with constants.