### PR TITLE
server: add deck confirm handler and pool/deck consistency checks

### DIFF
--- a/pkg/ocr/match.go
+++ b/pkg/ocr/match.go
@@ -41,14 +41,9 @@ const (
 	VeryLowConfidenceGap       = 0.20
 )
 
-// BasicLandNames are always recognized even when the cube list doesn't
-// contain them - they show up in every deck photo. They get a looser
-// threshold (BasicLandThreshold) and skip the short-name substring gate.
-var BasicLandNames = []string{
-	"Plains", "Island", "Swamp", "Mountain", "Forest", "Wastes",
-	"Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp",
-	"Snow-Covered Mountain", "Snow-Covered Forest", "Snow-Covered Wastes",
-}
+// Basic lands (types.BasicLandNames) are always recognized even when the cube
+// list doesn't contain them - they show up in every deck photo. They get a
+// looser threshold (BasicLandThreshold) and skip the short-name substring gate.
 
 // BasicLandThreshold is the minimum score for a basic land to count as high
 // confidence. Looser than HighConfidenceThreshold because basics are often
@@ -144,7 +139,7 @@ func MatchLine(text string, cube *types.Cube) MatchResult {
 	rawLower := strings.ToLower(text)
 	cleanedLower := strings.ToLower(cleaned)
 
-	cands := make([]Candidate, 0, len(cube.Names())+len(BasicLandNames))
+	cands := make([]Candidate, 0, len(cube.Names())+len(types.BasicLandNames))
 	scoreName := func(name string, applyShortGate bool) float64 {
 		lowerName := strings.ToLower(name)
 		targets := []string{lowerName}
@@ -188,7 +183,7 @@ func MatchLine(text string, cube *types.Cube) MatchResult {
 		return best
 	}
 	basicSet := map[string]bool{}
-	for _, name := range BasicLandNames {
+	for _, name := range types.BasicLandNames {
 		basicSet[name] = true
 	}
 	scoreAndCollect := func(name string, applyShortGate bool, minScore float64) {
@@ -205,7 +200,7 @@ func MatchLine(text string, cube *types.Cube) MatchResult {
 	// Also score basic lands, skipping the short-name gate and any already
 	// in the cube. Drop ones below their own threshold so they don't skew
 	// the gap against real cube cards.
-	for _, name := range BasicLandNames {
+	for _, name := range types.BasicLandNames {
 		if cubeSet[name] {
 			continue
 		}

--- a/pkg/server/ocr/confirm.go
+++ b/pkg/server/ocr/confirm.go
@@ -1,0 +1,117 @@
+package ocr
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+
+	"github.com/caseydavenport/cube-tools/pkg/server"
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+type CountedCard struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type ConfirmRequest struct {
+	Pool      []CountedCard  `json:"pool"`
+	Mainboard []CountedCard  `json:"mainboard"`
+	Basics    map[string]int `json:"basics"`
+}
+
+func expand(cards []CountedCard) []types.Card {
+	out := make([]types.Card, 0)
+	for _, c := range cards {
+		for i := 0; i < c.Count; i++ {
+			out = append(out, types.HydrateCard(c.Name))
+		}
+	}
+	return out
+}
+
+// deriveSideboard returns the pool multiset minus the played non-basic
+// mainboard multiset, per name, floored at zero.
+func deriveSideboard(pool, mainboard []CountedCard) []types.Card {
+	played := map[string]int{}
+	for _, c := range mainboard {
+		if !types.IsBasic(c.Name) {
+			played[c.Name] += c.Count
+		}
+	}
+	out := make([]types.Card, 0)
+	for _, c := range pool {
+		remaining := c.Count - played[c.Name]
+		for i := 0; i < remaining; i++ {
+			out = append(out, types.HydrateCard(c.Name))
+		}
+	}
+	return out
+}
+
+func buildDeck(existing *types.Deck, req ConfirmRequest) *types.Deck {
+	d := existing
+	hasMain := len(req.Mainboard) > 0 || len(req.Basics) > 0
+	if !hasMain {
+		d.Pool = expand(req.Pool)
+		d.Mainboard = []types.Card{}
+		d.Sideboard = []types.Card{}
+		return d
+	}
+	main := expand(req.Mainboard)
+	basics := make([]CountedCard, 0, len(req.Basics))
+	for name, n := range req.Basics {
+		basics = append(basics, CountedCard{Name: name, Count: n})
+	}
+	main = append(main, expand(basics)...)
+	d.Mainboard = main
+	d.Sideboard = deriveSideboard(req.Pool, req.Mainboard)
+	d.Pool = nil
+	return d
+}
+
+func ConfirmHandler() http.Handler { return ConfirmHandlerWithRoot("data") }
+
+func ConfirmHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		draftID := r.PathValue("draft_id")
+		player := r.PathValue("player")
+		if cube == "" || !validDraftID(draftID) || player == "" || !validDraftID(player) {
+			http.NotFound(rw, r)
+			return
+		}
+		var req ConfirmRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(rw, "Invalid request", http.StatusBadRequest)
+			return
+		}
+		deckPath := filepath.Join(dataRoot, cube, draftID, draftID+"-"+player+".json")
+		existing, err := types.LoadDeck(deckPath)
+		if err != nil {
+			http.Error(rw, "deck file not found: "+err.Error(), http.StatusNotFound)
+			return
+		}
+		d := buildDeck(existing, req)
+		if err := d.Save(deckPath); err != nil {
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		// Mark the player confirmed in the session, if one exists. Take the same
+		// lock as the autosave and background scan, since this is a load-modify-save
+		// on the shared session file and would otherwise race with them.
+		sessionSaveMu.Lock()
+		defer sessionSaveMu.Unlock()
+		if s, err := LoadSession(dataRoot, cube, draftID); err == nil {
+			if pw := s.Players[player]; pw != nil {
+				pw.Status = "confirmed"
+				if err := s.Save(dataRoot, cube); err != nil {
+					http.Error(rw, "Internal server error", http.StatusInternalServerError)
+					return
+				}
+			}
+		}
+		rw.WriteHeader(http.StatusOK)
+	})
+}

--- a/pkg/server/ocr/confirm_test.go
+++ b/pkg/server/ocr/confirm_test.go
@@ -1,0 +1,89 @@
+package ocr
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+func TestBuildDeckDerivesSideboardAndBasics(t *testing.T) {
+	existing := types.NewDeck()
+	existing.Player = "2026-01-17_evt_1-p3"
+	existing.Matches = []types.Match{{Opponent: "x", Wins: 2, Losses: 1}}
+
+	req := ConfirmRequest{
+		Pool: []CountedCard{
+			{Name: "Brainstorm", Count: 1},
+			{Name: "Counterspell", Count: 1},
+			{Name: "Misty Rainforest", Count: 2},
+		},
+		Mainboard: []CountedCard{
+			{Name: "Brainstorm", Count: 1},
+			{Name: "Misty Rainforest", Count: 2},
+		},
+		Basics: map[string]int{"Island": 7},
+	}
+	d := buildDeck(existing, req)
+
+	if len(d.Pool) != 0 {
+		t.Fatalf("pool should be empty when mainboard present, got %d", len(d.Pool))
+	}
+	main := cardCounts(d.Mainboard)
+	if main["Brainstorm"] != 1 || main["Misty Rainforest"] != 2 || main["Island"] != 7 {
+		t.Fatalf("mainboard counts = %+v", main)
+	}
+	side := cardCounts(d.Sideboard)
+	if side["Counterspell"] != 1 || len(side) != 1 {
+		t.Fatalf("sideboard = %+v, want just 1 Counterspell", side)
+	}
+	if len(d.Matches) != 1 {
+		t.Fatalf("matches must be preserved, got %d", len(d.Matches))
+	}
+}
+
+func TestBuildDeckPoolOnly(t *testing.T) {
+	req := ConfirmRequest{Pool: []CountedCard{{Name: "Brainstorm", Count: 1}, {Name: "Counterspell", Count: 1}}}
+	d := buildDeck(types.NewDeck(), req)
+	if len(d.Pool) != 2 {
+		t.Fatalf("pool = %d, want 2", len(d.Pool))
+	}
+	if len(d.Mainboard) != 0 || len(d.Sideboard) != 0 {
+		t.Fatalf("pool-only must leave main/side empty")
+	}
+}
+
+func cardCounts(cs []types.Card) map[string]int {
+	m := map[string]int{}
+	for _, c := range cs {
+		m[c.Name]++
+	}
+	return m
+}
+
+func TestConfirmHandlerWritesDeckFile(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	deckPath := filepath.Join(root, "polyverse", draftID, draftID+"-p3.json")
+	writeFile(t, deckPath,
+		`{"metadata":{"draft_id":"`+draftID+`","path":"`+deckPath+`"},"player":"`+draftID+`-p3","date":"2026-01-17","labels":[],"matches":[],"mainboard":[],"sideboard":[]}`)
+
+	h := ConfirmHandlerWithRoot(root)
+	r := reqWithCube(t, "POST", "/api/polyverse/ocr/drafts/"+draftID+"/players/p3/confirm", "polyverse")
+	r.SetPathValue("draft_id", draftID)
+	r.SetPathValue("player", "p3")
+	r.Body = bodyOf(`{"pool":[{"name":"Brainstorm","count":1}]}`)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	d, err := types.LoadDeck(deckPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Pool) != 1 || d.Pool[0].Name != "Brainstorm" {
+		t.Fatalf("written pool = %+v", d.Pool)
+	}
+}

--- a/pkg/server/ocr/playerchecks.go
+++ b/pkg/server/ocr/playerchecks.go
@@ -1,0 +1,122 @@
+package ocr
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+// poolCountsFromEntries sums a session's saved pool list by lowercased name,
+// excluding basics (entered through their own control, not part of the cube).
+func poolCountsFromEntries(entries []PoolEntry) map[string]int {
+	counts := map[string]int{}
+	for _, e := range entries {
+		if e.Count <= 0 || types.IsBasic(e.CardName) {
+			continue
+		}
+		counts[strings.ToLower(e.CardName)] += e.Count
+	}
+	return counts
+}
+
+// poolCountsFromDeck reconstructs the confirmed pool from a written deck so it
+// can be compared against the live session. A pool-only player stores the pool
+// directly; a player who built a mainboard stored pool = non-basic mainboard +
+// sideboard (basics excluded), matching how confirm splits them.
+func poolCountsFromDeck(d *types.Deck) map[string]int {
+	counts := map[string]int{}
+	add := func(cards []types.Card) {
+		for _, c := range cards {
+			if types.IsBasic(c.Name) {
+				continue
+			}
+			counts[strings.ToLower(c.Name)]++
+		}
+	}
+	if len(d.Pool) > 0 {
+		add(d.Pool)
+		return counts
+	}
+	add(d.Mainboard)
+	add(d.Sideboard)
+	return counts
+}
+
+// needsReconfirm reports whether a confirmed player's deck on disk is stale: the
+// live session pool no longer matches what was written. Editing a confirmed
+// player (a consistency-panel fix, or the workspace) updates the session but not
+// the deck, so the deck must be re-confirmed to catch up.
+func needsReconfirm(pw *PlayerWork, d *types.Deck) bool {
+	if pw == nil || d == nil {
+		return false
+	}
+
+	// No scanned pool means there's nothing to compare against the deck. This
+	// happens for a deck-only scan or stray scratch work on a draft that was
+	// confirmed outside the pool flow, so don't flag it as stale.
+	if len(pw.PoolEntries) == 0 {
+		return false
+	}
+	return !equalCounts(poolCountsFromEntries(pw.PoolEntries), poolCountsFromDeck(d))
+}
+
+func equalCounts(a, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// deckWarnings mirrors the client cross-check (ui/src/utils/CrossCheck.js) from
+// the session's saved derived lists, so the draft view can flag a confirmed deck
+// whose pool/mainboard doesn't add up without opening each player.
+func deckWarnings(pw *PlayerWork) []string {
+	if pw == nil {
+		return nil
+	}
+
+	// Every check below is relative to the scanned pool, so without one there's
+	// nothing meaningful to say. Skips deck-only scans and stray scratch work,
+	// which would otherwise report a bogus "Pool has 0 cards".
+	if len(pw.PoolEntries) == 0 {
+		return nil
+	}
+	poolTotal := 0
+	poolByName := map[string]int{}
+	for _, e := range pw.PoolEntries {
+		poolTotal += e.Count
+		poolByName[e.CardName] = e.Count
+	}
+	basicTotal := 0
+	for _, n := range pw.Basics {
+		basicTotal += n
+	}
+
+	var w []string
+	if poolTotal != 45 {
+		w = append(w, fmt.Sprintf("Pool has %d cards (expected 45)", poolTotal))
+	}
+	mainNonBasic := 0
+	for _, e := range pw.MainboardEntries {
+		if types.IsBasic(e.CardName) {
+			continue
+		}
+		mainNonBasic += e.Count
+		switch {
+		case poolByName[e.CardName] == 0:
+			w = append(w, fmt.Sprintf("%q is in the deck but not the pool", e.CardName))
+		case e.Count > poolByName[e.CardName]:
+			w = append(w, fmt.Sprintf("%q x%d exceeds pool (%d)", e.CardName, e.Count, poolByName[e.CardName]))
+		}
+	}
+	if size := mainNonBasic + basicTotal; size > 0 && (size < 38 || size > 46) {
+		w = append(w, fmt.Sprintf("Mainboard has %d cards (expected ~40)", size))
+	}
+	return w
+}

--- a/pkg/server/ocr/playerchecks_test.go
+++ b/pkg/server/ocr/playerchecks_test.go
@@ -1,0 +1,129 @@
+package ocr
+
+import (
+	"testing"
+
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+func cards(names ...string) []types.Card {
+	out := make([]types.Card, len(names))
+	for i, n := range names {
+		out[i] = types.Card{Name: n}
+	}
+	return out
+}
+
+func TestNeedsReconfirm(t *testing.T) {
+	t.Run("pool-only deck matches session", func(t *testing.T) {
+		pw := pool(entry("Brainstorm", 2), entry("Misty Rainforest", 1))
+		d := &types.Deck{Pool: cards("Brainstorm", "Brainstorm", "Misty Rainforest")}
+		if needsReconfirm(pw, d) {
+			t.Fatal("matching pool should not need reconfirm")
+		}
+	})
+
+	t.Run("pool-only deck differs from session", func(t *testing.T) {
+		// Session was fixed (Brainstrm renamed to Brainstorm) but the deck on
+		// disk still has the misread.
+		pw := pool(entry("Brainstorm", 2))
+		d := &types.Deck{Pool: cards("Brainstorm", "Brainstrm")}
+		if !needsReconfirm(pw, d) {
+			t.Fatal("changed pool should need reconfirm")
+		}
+	})
+
+	t.Run("mainboard deck reconstructs pool from mainboard plus sideboard", func(t *testing.T) {
+		// Pool = 2x Brainstorm, 1x Misty Rainforest. Deck plays one Brainstorm
+		// (plus a basic), the rest is sideboard. Basics are ignored.
+		pw := pool(entry("Brainstorm", 2), entry("Misty Rainforest", 1))
+		d := &types.Deck{
+			Mainboard: cards("Brainstorm", "Island"),
+			Sideboard: cards("Brainstorm", "Misty Rainforest"),
+		}
+		if needsReconfirm(pw, d) {
+			t.Fatal("reconstructed pool should match session")
+		}
+	})
+
+	t.Run("deck-only session with no pool work never needs reconfirm", func(t *testing.T) {
+		// A scratch deck scan (mainboard only, no pool) on a draft confirmed
+		// outside the pool flow should not be flagged stale.
+		pw := &PlayerWork{MainboardEntries: []PoolEntry{entry("Wrath of God", 1)}}
+		d := &types.Deck{Mainboard: cards("Wrath of God", "Island"), Sideboard: cards("Brainstorm")}
+		if needsReconfirm(pw, d) {
+			t.Fatal("session with no pool entries should not need reconfirm")
+		}
+	})
+
+	t.Run("nil session or deck never needs reconfirm", func(t *testing.T) {
+		if needsReconfirm(nil, &types.Deck{Pool: cards("Brainstorm")}) {
+			t.Fatal("nil session should not need reconfirm")
+		}
+		if needsReconfirm(pool(entry("Brainstorm", 1)), nil) {
+			t.Fatal("nil deck should not need reconfirm")
+		}
+	})
+}
+
+func TestDeckWarnings(t *testing.T) {
+	t.Run("clean 45-card pool, no mainboard", func(t *testing.T) {
+		pw := pool(entry("Brainstorm", 45))
+		if w := deckWarnings(pw); len(w) != 0 {
+			t.Fatalf("expected no warnings, got %v", w)
+		}
+	})
+
+	t.Run("deck-only session with no pool work has no warnings", func(t *testing.T) {
+		// Mainboard scanned but no pool: the pool-relative checks can't run, so
+		// don't emit a bogus "Pool has 0 cards" or not-in-pool warning.
+		pw := &PlayerWork{MainboardEntries: []PoolEntry{entry("Wrath of God", 1)}}
+		if w := deckWarnings(pw); len(w) != 0 {
+			t.Fatalf("expected no warnings for deck-only session, got %v", w)
+		}
+	})
+
+	t.Run("pool not 45", func(t *testing.T) {
+		pw := pool(entry("Brainstorm", 44))
+		w := deckWarnings(pw)
+		if len(w) != 1 {
+			t.Fatalf("expected 1 warning, got %v", w)
+		}
+	})
+
+	t.Run("mainboard card not in pool", func(t *testing.T) {
+		pw := &PlayerWork{
+			PoolEntries:      []PoolEntry{entry("Brainstorm", 45)},
+			MainboardEntries: []PoolEntry{entry("Counterspell", 1)},
+		}
+		w := deckWarnings(pw)
+		found := false
+		for _, m := range w {
+			if m == `"Counterspell" is in the deck but not the pool` {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected not-in-pool warning, got %v", w)
+		}
+	})
+
+	t.Run("mainboard size out of range, basics counted", func(t *testing.T) {
+		pw := &PlayerWork{
+			PoolEntries:      []PoolEntry{entry("Brainstorm", 45)},
+			MainboardEntries: []PoolEntry{entry("Brainstorm", 20)},
+			Basics:           map[string]int{"Island": 5},
+		}
+		// 20 non-basic + 5 basics = 25, well under 38.
+		w := deckWarnings(pw)
+		found := false
+		for _, m := range w {
+			if m == "Mainboard has 25 cards (expected ~40)" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected mainboard-size warning, got %v", w)
+		}
+	})
+}

--- a/pkg/server/ocr/util_test.go
+++ b/pkg/server/ocr/util_test.go
@@ -35,3 +35,9 @@ func writeFile(t *testing.T, path, body string) {
 		t.Fatal(err)
 	}
 }
+
+// pool builds a PlayerWork with just the given pool entries, the common shape
+// for the pool/deck consistency checks.
+func pool(entries ...PoolEntry) *PlayerWork { return &PlayerWork{PoolEntries: entries} }
+
+func entry(name string, count int) PoolEntry { return PoolEntry{CardName: name, Count: count} }

--- a/pkg/types/basics.go
+++ b/pkg/types/basics.go
@@ -1,0 +1,20 @@
+package types
+
+// BasicLandNames lists the basic lands. They aren't part of any cube list - every
+// deck supplies its own - so code that reasons about pools and decks treats them
+// specially rather than looking them up in the cube.
+var BasicLandNames = []string{
+	"Plains", "Island", "Swamp", "Mountain", "Forest", "Wastes",
+	"Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp",
+	"Snow-Covered Mountain", "Snow-Covered Forest", "Snow-Covered Wastes",
+}
+
+// IsBasic reports whether name is a basic land.
+func IsBasic(name string) bool {
+	for _, b := range BasicLandNames {
+		if b == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Confirm handler writes a player's deck (splitting pool/mainboard/sideboard, deriving basics) and marks them confirmed in the session under the autosave lock so it can't race the background scan. Adds the pool/deck reconfirm + warning checks. Basic lands aren't OCR-specific, so BasicLandNames and a new IsBasic now live in pkg/types, with pkg/ocr and the server package using them.