### PR TITLE
server: add OCR draft list, detail, and card endpoints

### DIFF
--- a/pkg/commands/import_hedron.go
+++ b/pkg/commands/import_hedron.go
@@ -205,6 +205,7 @@ func importDraft(cube string, d *HedronDraft, seq int) {
 	draftMeta := &types.DraftMetadata{
 		EventName:        d.EventName,
 		EventDescription: fmt.Sprintf("Imported from Hedron Network. Event Code: %s, Flight: %s", d.EventCode, d.FlightName),
+		Flight:           d.FlightName,
 	}
 	if err := draftMeta.Save(outdir); err != nil {
 		logrus.WithError(err).Fatal("Failed to write draft metadata")

--- a/pkg/server/ocr/cards.go
+++ b/pkg/server/ocr/cards.go
@@ -1,0 +1,41 @@
+package ocr
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/caseydavenport/cube-tools/pkg/server"
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+func CardsHandler() http.Handler { return CardsHandlerWithRoot("data") }
+
+func CardsHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		draftID := r.PathValue("draft_id")
+		if cube == "" || draftID == "" || strings.ContainsAny(draftID, `/\`) || strings.Contains(draftID, "..") {
+			http.NotFound(rw, r)
+			return
+		}
+		date := ""
+		if len(draftID) >= 10 {
+			date = draftID[:10]
+		}
+		cl, err := types.LoadCubeList(types.LoadOptions{DataRoot: dataRoot, Cube: cube, Date: date})
+		if err != nil {
+			// Fall back to latest snapshot when the exact date has none.
+			cl, err = types.LoadCubeList(types.LoadOptions{DataRoot: dataRoot, Cube: cube})
+			if err != nil {
+				http.Error(rw, "no cube list: "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+		var cards []CardInfo
+		for _, name := range cl.Names() {
+			isLand := strings.Contains(types.GetOracleData(name).TypeLine, "Land")
+			cards = append(cards, CardInfo{Name: name, MaxCopies: cl.MaxCopies(name), IsLand: isLand})
+		}
+		writeJSON(rw, map[string]any{"cards": cards})
+	})
+}

--- a/pkg/server/ocr/cards_test.go
+++ b/pkg/server/ocr/cards_test.go
@@ -1,0 +1,38 @@
+package ocr
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func TestCardsHandler(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	// cube snapshot for the draft date: two of "Misty Rainforest", one "Brainstorm".
+	writeFile(t, filepath.Join(root, "polyverse", "2026-01-17", "cube-snapshot.json"),
+		`{"cards":[{"name":"Brainstorm"},{"name":"Misty Rainforest"},{"name":"Misty Rainforest"}]}`)
+
+	h := CardsHandlerWithRoot(root)
+	r := reqWithCube(t, "GET", "/api/polyverse/ocr/drafts/"+draftID+"/cards", "polyverse")
+	r.SetPathValue("draft_id", draftID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var out struct {
+		Cards []CardInfo `json:"cards"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	caps := map[string]int{}
+	for _, c := range out.Cards {
+		caps[c.Name] = c.MaxCopies
+	}
+	if caps["Misty Rainforest"] != 2 || caps["Brainstorm"] != 1 {
+		t.Fatalf("caps = %+v", caps)
+	}
+}

--- a/pkg/server/ocr/drafts.go
+++ b/pkg/server/ocr/drafts.go
@@ -1,0 +1,181 @@
+package ocr
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/caseydavenport/cube-tools/pkg/server"
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+func isDraftDir(name string) bool {
+	// YYYY-MM-DD_... — date prefix then an underscore.
+	return len(name) >= 11 && name[4] == '-' && name[7] == '-' && name[10] == '_'
+}
+
+func readDraftMeta(dataRoot, cube, draftID string) *types.DraftMetadata {
+	m, err := types.LoadDraftMetadata(filepath.Join(dataRoot, cube, draftID))
+	if err != nil {
+		return &types.DraftMetadata{}
+	}
+	return m
+}
+
+func discoverPlayers(dataRoot, cube, draftID string) ([]PlayerDetail, error) {
+	imgDir := filepath.Join(dataRoot, cube, draftID, "img")
+	entries, err := os.ReadDir(imgDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// The session (if any) tells us which players have OCR work saved, so we
+	// can distinguish "in progress" from "unstarted". A missing or unreadable
+	// session just means no work has been saved yet.
+	sess, err := LoadSession(dataRoot, cube, draftID)
+	if err != nil {
+		sess = &Session{Players: map[string]*PlayerWork{}}
+	}
+
+	var out []PlayerDetail
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		short := e.Name()
+		pd := PlayerDetail{ID: short}
+		files, err := os.ReadDir(filepath.Join(imgDir, short))
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range files {
+			rel := draftID + "/img/" + short + "/" + f.Name()
+			switch {
+			case strings.HasPrefix(f.Name(), "checkin-"):
+				pd.Photos.Checkin = append(pd.Photos.Checkin, rel)
+			case strings.HasPrefix(f.Name(), "checkout-"):
+				pd.Photos.Checkout = append(pd.Photos.Checkout, rel)
+			case strings.HasPrefix(f.Name(), "deck-"):
+				pd.Photos.Deck = append(pd.Photos.Deck, rel)
+			}
+		}
+		sort.Strings(pd.Photos.Checkin)
+		sort.Strings(pd.Photos.Checkout)
+		sort.Strings(pd.Photos.Deck)
+
+		pw := sess.Players[short]
+		deckPath := filepath.Join(dataRoot, cube, draftID, draftID+"-"+short+".json")
+		if d, err := types.LoadDeck(deckPath); err == nil {
+			pd.Matches = d.Matches
+			pd.HasDeck = len(d.Mainboard) > 0 || len(d.Pool) > 0
+			if pd.HasDeck {
+				pd.NeedsReconfirm = needsReconfirm(pw, d)
+				pd.Warnings = deckWarnings(pw)
+			}
+		}
+		pd.Status = playerStatus(pw, pd.HasDeck)
+		out = append(out, pd)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// playerStatus classifies a player's progress for the draft list indicator.
+// "done" once their deck has been written (the confirm step), "in_progress"
+// once any OCR work has been saved for them, else "unstarted".
+func playerStatus(pw *PlayerWork, hasDeck bool) string {
+	if hasDeck || (pw != nil && pw.Status == "confirmed") {
+		return "done"
+	}
+	if pw != nil && (len(pw.Boxes) > 0 || len(pw.DeckBoxes) > 0 ||
+		len(pw.PoolEntries) > 0 || len(pw.MainboardEntries) > 0 || len(pw.Basics) > 0) {
+		return "in_progress"
+	}
+	return "unstarted"
+}
+
+func DraftsHandler() http.Handler { return DraftsHandlerWithRoot("data") }
+
+func DraftsHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		entries, err := os.ReadDir(filepath.Join(dataRoot, cube))
+		if os.IsNotExist(err) {
+			writeJSON(rw, map[string]any{"drafts": []DraftSummary{}})
+			return
+		}
+		if err != nil {
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		var summaries []DraftSummary
+		for _, e := range entries {
+			if !e.IsDir() || !isDraftDir(e.Name()) {
+				continue
+			}
+			draftID := e.Name()
+			players, err := discoverPlayers(dataRoot, cube, draftID)
+			if err != nil || len(players) == 0 {
+				continue
+			}
+			confirmed, reconfirm, warned := 0, 0, 0
+			for _, p := range players {
+				if p.HasDeck {
+					confirmed++
+				}
+				if p.NeedsReconfirm {
+					reconfirm++
+				}
+				if len(p.Warnings) > 0 {
+					warned++
+				}
+			}
+			meta := readDraftMeta(dataRoot, cube, draftID)
+			summaries = append(summaries, DraftSummary{
+				DraftID:         draftID,
+				EventName:       meta.EventName,
+				Flight:          meta.Flight,
+				Players:         len(players),
+				Confirmed:       confirmed,
+				ReconfirmNeeded: reconfirm,
+				Warnings:        warned,
+			})
+		}
+		sort.Slice(summaries, func(i, j int) bool { return summaries[i].DraftID > summaries[j].DraftID })
+		writeJSON(rw, map[string]any{"drafts": summaries})
+	})
+}
+
+func DraftDetailHandler() http.Handler { return DraftDetailHandlerWithRoot("data") }
+
+func DraftDetailHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		draftID := r.PathValue("draft_id")
+		if cube == "" || draftID == "" || strings.ContainsAny(draftID, `/\`) || strings.Contains(draftID, "..") {
+			http.NotFound(rw, r)
+			return
+		}
+		players, err := discoverPlayers(dataRoot, cube, draftID)
+		if err != nil {
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		if players == nil {
+			http.NotFound(rw, r)
+			return
+		}
+		meta := readDraftMeta(dataRoot, cube, draftID)
+		writeJSON(rw, DraftDetail{
+			DraftID:   draftID,
+			EventName: meta.EventName,
+			Flight:    meta.Flight,
+			Players:   players,
+		})
+	})
+}

--- a/pkg/server/ocr/drafts_test.go
+++ b/pkg/server/ocr/drafts_test.go
@@ -1,0 +1,122 @@
+package ocr
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverPlayers(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	base := filepath.Join(root, "polyverse", draftID)
+	writeFile(t, filepath.Join(base, "img", "p3", "checkin-1.jpg"), "x")
+	writeFile(t, filepath.Join(base, "img", "p3", "checkin-2.jpg"), "x")
+	writeFile(t, filepath.Join(base, "img", "p3", "deck-1.jpg"), "x")
+	// deck file with no cards yet (as import-hedron leaves it)
+	writeFile(t, filepath.Join(base, draftID+"-p3.json"),
+		`{"metadata":{"draft_id":"`+draftID+`"},"player":"`+draftID+`-p3","date":"2026-01-17","labels":[],"matches":[{"opponent":"`+draftID+`-p5","wins":2,"losses":1}],"mainboard":[],"sideboard":[]}`)
+
+	players, err := discoverPlayers(root, "polyverse", draftID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(players) != 1 {
+		t.Fatalf("players = %d, want 1", len(players))
+	}
+	p := players[0]
+	if p.ID != "p3" {
+		t.Fatalf("id = %q, want p3", p.ID)
+	}
+	if len(p.Photos.Checkin) != 2 || len(p.Photos.Deck) != 1 {
+		t.Fatalf("photos = %+v", p.Photos)
+	}
+	if p.Photos.Checkin[0] != draftID+"/img/p3/checkin-1.jpg" {
+		t.Fatalf("checkin[0] = %q", p.Photos.Checkin[0])
+	}
+	if p.HasDeck {
+		t.Fatalf("HasDeck should be false for empty deck")
+	}
+	if len(p.Matches) != 1 {
+		t.Fatalf("matches = %d, want 1", len(p.Matches))
+	}
+}
+
+func TestDraftDetailHandler(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	base := filepath.Join(root, "polyverse", draftID)
+	writeFile(t, filepath.Join(base, "img", "p3", "checkin-1.jpg"), "x")
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/{cube}/ocr/drafts/{draft_id}", DraftDetailHandlerWithRoot(root))
+
+	t.Run("valid draft with one player returns 200", func(t *testing.T) {
+		r := reqWithCube(t, "GET", "/api/polyverse/ocr/drafts/"+draftID, "polyverse")
+		r.SetPathValue("draft_id", draftID)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+		var out DraftDetail
+		if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Players) != 1 || out.Players[0].ID != "p3" {
+			t.Fatalf("players = %+v", out.Players)
+		}
+	})
+
+	t.Run("unknown draft_id returns 404", func(t *testing.T) {
+		r := reqWithCube(t, "GET", "/api/polyverse/ocr/drafts/2099-01-01_no_such", "polyverse")
+		r.SetPathValue("draft_id", "2099-01-01_no_such")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("traversal draft_id returns 404", func(t *testing.T) {
+		r := reqWithCube(t, "GET", "/api/polyverse/ocr/drafts/..%2F..%2Fetc%2Fpasswd", "polyverse")
+		r.SetPathValue("draft_id", "../../etc/passwd")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", w.Code)
+		}
+	})
+}
+
+func TestDraftsHandlerListsDraftsWithImages(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	base := filepath.Join(root, "polyverse", draftID)
+	writeFile(t, filepath.Join(base, "img", "p3", "checkin-1.jpg"), "x")
+	writeFile(t, filepath.Join(base, "metadata.json"), `{"event_name":"Friday Night","flight":"Saturday Morning"}`)
+	writeFile(t, filepath.Join(base, draftID+"-p3.json"),
+		`{"metadata":{"draft_id":"`+draftID+`"},"player":"`+draftID+`-p3","date":"2026-01-17","labels":[],"matches":[],"mainboard":[],"sideboard":[]}`)
+
+	h := DraftsHandlerWithRoot(root)
+	r := reqWithCube(t, "GET", "/api/polyverse/ocr/drafts", "polyverse")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var out struct {
+		Drafts []DraftSummary `json:"drafts"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Drafts) != 1 || out.Drafts[0].EventName != "Friday Night" || out.Drafts[0].Players != 1 {
+		t.Fatalf("drafts = %+v", out.Drafts)
+	}
+	if out.Drafts[0].Flight != "Saturday Morning" {
+		t.Fatalf("flight = %q, want Saturday Morning", out.Drafts[0].Flight)
+	}
+}

--- a/pkg/types/deck.go
+++ b/pkg/types/deck.go
@@ -104,7 +104,7 @@ func (d *Deck) Save(path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, bs, 0644)
+	return os.WriteFile(path, bs, 0o644)
 }
 
 func LoadDeck(path string) (*Deck, error) {
@@ -173,6 +173,7 @@ type DraftMetadata struct {
 	DraftID          string `json:"draft_id,omitempty"`
 	EventName        string `json:"event_name,omitempty"`
 	EventDescription string `json:"event_description,omitempty"`
+	Flight           string `json:"flight,omitempty"`
 }
 
 // DraftMetadataFilename is the filename used for the per-draft metadata file.
@@ -202,7 +203,7 @@ func (m *DraftMetadata) Save(dir string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, DraftMetadataFilename), bs, 0644)
+	return os.WriteFile(filepath.Join(dir, DraftMetadataFilename), bs, 0o644)
 }
 
 func (m *Metadata) GetSourceFiles() []string {


### PR DESCRIPTION
Adds the drafts list/detail and cards server handlers from the photo-OCR branch. Also restores the `Flight` field on `DraftMetadata` (dropped in the deck-JSON refactor) since the data files, server response, and UI all still use it.