### PR TITLE
server: add OCR pool-vs-cube consistency report and draft conflict badge

### DIFF
--- a/pkg/server/ocr/cards.go
+++ b/pkg/server/ocr/cards.go
@@ -18,18 +18,10 @@ func CardsHandlerWithRoot(dataRoot string) http.Handler {
 			http.NotFound(rw, r)
 			return
 		}
-		date := ""
-		if len(draftID) >= 10 {
-			date = draftID[:10]
-		}
-		cl, err := types.LoadCubeList(types.LoadOptions{DataRoot: dataRoot, Cube: cube, Date: date})
+		cl, err := loadCubeForDraft(dataRoot, cube, draftID)
 		if err != nil {
-			// Fall back to latest snapshot when the exact date has none.
-			cl, err = types.LoadCubeList(types.LoadOptions{DataRoot: dataRoot, Cube: cube})
-			if err != nil {
-				http.Error(rw, "no cube list: "+err.Error(), http.StatusInternalServerError)
-				return
-			}
+			http.Error(rw, "no cube list: "+err.Error(), http.StatusInternalServerError)
+			return
 		}
 		var cards []CardInfo
 		for _, name := range cl.Names() {

--- a/pkg/server/ocr/consistency.go
+++ b/pkg/server/ocr/consistency.go
@@ -1,0 +1,218 @@
+package ocr
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+	"github.com/caseydavenport/cube-tools/pkg/server"
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+// Discrepancy is one card whose total across all pools doesn't match the cube
+// list. Kind is "over" (pooled more copies than the cube has), "missing"
+// (fewer, including zero), or "unknown" (a name not in the cube at all).
+type Discrepancy struct {
+	CardName string `json:"card_name"`
+	Pooled   int    `json:"pooled"`
+	Cube     int    `json:"cube"`
+	Kind     string `json:"kind"`
+
+	// Captures are the pool boxes (across players) that resolved to this name,
+	// so the fix UI can show each one and reassign it. Only populated for "over"
+	// and "unknown" (a "missing" card has no boxes by definition).
+	Captures []Capture `json:"captures,omitempty"`
+}
+
+// Capture is one pool box that resolved to a discrepancy's card name, with
+// enough to crop its nameplate and reassign it from the draft view.
+type Capture struct {
+	Player     string             `json:"player"`
+	Photo      string             `json:"photo"`
+	BoxID      string             `json:"box_id"`
+	Bbox       ocrpkg.Bbox        `json:"bbox"`
+	Chosen     string             `json:"chosen"`
+	Candidates []ocrpkg.Candidate `json:"candidates,omitempty"`
+}
+
+// ConsistencyReport compares the sum of every player's pool against the cube
+// list. A clean draft pools each cube card exactly its max-copies count, so any
+// discrepancy points at an OCR miss (over/unknown) or a player not yet done
+// (missing).
+type ConsistencyReport struct {
+	PoolTotal      int           `json:"pool_total"`
+	CubeTotal      int           `json:"cube_total"`
+	PlayersCounted int           `json:"players_counted"`
+	PlayersTotal   int           `json:"players_total"`
+	Discrepancies  []Discrepancy `json:"discrepancies"`
+}
+
+// over and unknown are real OCR errors regardless of progress, so they sort
+// ahead of missing (which is expected until every player is scanned).
+var discrepancyOrder = map[string]int{
+	"unknown": 0,
+	"over":    1,
+	"missing": 2,
+}
+
+// Conflicts counts the discrepancies that are real OCR errors (over-counts and
+// names not in the cube), ignoring "missing" which is expected until every
+// player is scanned. The draft list uses this for a per-draft warning badge.
+func (r ConsistencyReport) Conflicts() int {
+	n := 0
+	for _, d := range r.Discrepancies {
+		if d.Kind == "over" || d.Kind == "unknown" {
+			n++
+		}
+	}
+	return n
+}
+
+func buildConsistencyReport(cl *types.Cube, sess *Session, playersTotal int) ConsistencyReport {
+	// Pool counts summed across players, keyed by lowercased name so they line
+	// up with the cube's case-insensitive copy counts. Basics are entered
+	// through their own control and aren't part of the cube list, so skip them.
+	pooled := map[string]int{}
+	display := map[string]string{}
+	counted := 0
+	for _, pw := range sess.Players {
+		if pw == nil {
+			continue
+		}
+		had := false
+		for _, e := range pw.PoolEntries {
+			if e.Count <= 0 || types.IsBasic(e.CardName) {
+				continue
+			}
+			key := strings.ToLower(e.CardName)
+			pooled[key] += e.Count
+			if _, ok := display[key]; !ok {
+				display[key] = e.CardName
+			}
+			had = true
+		}
+		if had {
+			counted++
+		}
+	}
+
+	report := ConsistencyReport{PlayersCounted: counted, PlayersTotal: playersTotal}
+	inCube := map[string]bool{}
+	for _, name := range cl.Names() {
+		want := cl.MaxCopies(name)
+		report.CubeTotal += want
+		key := strings.ToLower(name)
+		inCube[key] = true
+		if got := pooled[key]; got != want {
+			kind := "missing"
+			if got > want {
+				kind = "over"
+			}
+			report.Discrepancies = append(report.Discrepancies, Discrepancy{CardName: name, Pooled: got, Cube: want, Kind: kind})
+		}
+	}
+	for key, got := range pooled {
+		report.PoolTotal += got
+		if !inCube[key] {
+			report.Discrepancies = append(report.Discrepancies, Discrepancy{CardName: display[key], Pooled: got, Cube: 0, Kind: "unknown"})
+		}
+	}
+	attachCaptures(&report, sess)
+	sort.Slice(report.Discrepancies, func(i, j int) bool {
+		a, b := report.Discrepancies[i], report.Discrepancies[j]
+		if a.Kind != b.Kind {
+			return discrepancyOrder[a.Kind] < discrepancyOrder[b.Kind]
+		}
+		return a.CardName < b.CardName
+	})
+	return report
+}
+
+// attachCaptures fills in the pool boxes behind each over/unknown discrepancy
+// so the draft view can show and reassign them. A missing card has no boxes
+// (that's why it's missing), so it gets none.
+func attachCaptures(report *ConsistencyReport, sess *Session) {
+	want := map[string]bool{}
+	for _, d := range report.Discrepancies {
+		if d.Kind == "over" || d.Kind == "unknown" {
+			want[strings.ToLower(d.CardName)] = true
+		}
+	}
+	if len(want) == 0 {
+		return
+	}
+
+	byName := map[string][]Capture{}
+	for player, pw := range sess.Players {
+		if pw == nil {
+			continue
+		}
+		for photo, boxes := range pw.Boxes {
+			for _, b := range boxes {
+				if b.Chosen == "" || b.Status == "pending" || b.Status == "unmatched" {
+					continue
+				}
+				key := strings.ToLower(b.Chosen)
+				if !want[key] {
+					continue
+				}
+				byName[key] = append(byName[key], Capture{
+					Player:     player,
+					Photo:      photo,
+					BoxID:      b.ID,
+					Bbox:       b.Bbox,
+					Chosen:     b.Chosen,
+					Candidates: b.Candidates,
+				})
+			}
+		}
+	}
+
+	for i := range report.Discrepancies {
+		d := &report.Discrepancies[i]
+		if caps := byName[strings.ToLower(d.CardName)]; len(caps) > 0 {
+			sort.Slice(caps, func(a, b int) bool {
+				if caps[a].Player != caps[b].Player {
+					return caps[a].Player < caps[b].Player
+				}
+				return caps[a].Photo < caps[b].Photo
+			})
+			d.Captures = caps
+		}
+	}
+}
+
+func ConsistencyHandler() http.Handler { return ConsistencyHandlerWithRoot("data") }
+
+func ConsistencyHandlerWithRoot(dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		draftID := r.PathValue("draft_id")
+		if cube == "" || !validDraftID(draftID) {
+			http.NotFound(rw, r)
+			return
+		}
+		players, err := discoverPlayers(dataRoot, cube, draftID)
+		if err != nil {
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		if players == nil {
+			http.NotFound(rw, r)
+			return
+		}
+
+		cl, err := loadCubeForDraft(dataRoot, cube, draftID)
+		if err != nil {
+			http.Error(rw, "no cube list: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		sess, err := LoadSession(dataRoot, cube, draftID)
+		if err != nil {
+			sess = &Session{Players: map[string]*PlayerWork{}}
+		}
+		writeJSON(rw, buildConsistencyReport(cl, sess, len(players)))
+	})
+}

--- a/pkg/server/ocr/consistency_test.go
+++ b/pkg/server/ocr/consistency_test.go
@@ -1,0 +1,202 @@
+package ocr
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+// loadTestCube writes a snapshot and loads it as a cube for the pure-function
+// tests. The snapshot repeats a name once per copy, matching the real format.
+func loadTestCube(t *testing.T, body string) *types.Cube {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "polyverse", "2026-01-17", "cube-snapshot.json"), body)
+	cl, err := types.LoadCubeList(types.LoadOptions{DataRoot: root, Cube: "polyverse", Date: "2026-01-17"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cl
+}
+
+func TestBuildConsistencyReport(t *testing.T) {
+	// Cube has 2x Brainstorm, 1x Misty Rainforest.
+	cl := loadTestCube(t, `{"cards":[{"name":"Brainstorm"},{"name":"Brainstorm"},{"name":"Misty Rainforest"}]}`)
+
+	t.Run("clean", func(t *testing.T) {
+		sess := &Session{Players: map[string]*PlayerWork{
+			"a": pool(entry("Brainstorm", 1), entry("Misty Rainforest", 1)),
+			"b": pool(entry("Brainstorm", 1)),
+		}}
+		got := buildConsistencyReport(cl, sess, 2)
+		if len(got.Discrepancies) != 0 {
+			t.Fatalf("expected no discrepancies, got %+v", got.Discrepancies)
+		}
+		if got.PoolTotal != 3 || got.CubeTotal != 3 {
+			t.Fatalf("totals: pool=%d cube=%d", got.PoolTotal, got.CubeTotal)
+		}
+		if got.PlayersCounted != 2 || got.PlayersTotal != 2 {
+			t.Fatalf("players: counted=%d total=%d", got.PlayersCounted, got.PlayersTotal)
+		}
+	})
+
+	t.Run("over", func(t *testing.T) {
+		// Three copies of a 2-copy card: an OCR over-count.
+		sess := &Session{Players: map[string]*PlayerWork{
+			"a": pool(entry("Brainstorm", 2)),
+			"b": pool(entry("Brainstorm", 1), entry("Misty Rainforest", 1)),
+		}}
+		got := buildConsistencyReport(cl, sess, 2)
+		if len(got.Discrepancies) != 1 {
+			t.Fatalf("expected 1 discrepancy, got %+v", got.Discrepancies)
+		}
+		d := got.Discrepancies[0]
+		if d.CardName != "Brainstorm" || d.Kind != "over" || d.Pooled != 3 || d.Cube != 2 {
+			t.Fatalf("discrepancy = %+v", d)
+		}
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		// Only one Brainstorm pooled, Misty Rainforest not scanned at all.
+		sess := &Session{Players: map[string]*PlayerWork{
+			"a": pool(entry("Brainstorm", 1)),
+		}}
+		got := buildConsistencyReport(cl, sess, 2)
+		kinds := map[string]Discrepancy{}
+		for _, d := range got.Discrepancies {
+			kinds[d.CardName] = d
+		}
+		if kinds["Brainstorm"].Kind != "missing" || kinds["Brainstorm"].Pooled != 1 {
+			t.Fatalf("Brainstorm = %+v", kinds["Brainstorm"])
+		}
+		if kinds["Misty Rainforest"].Kind != "missing" || kinds["Misty Rainforest"].Pooled != 0 {
+			t.Fatalf("Misty Rainforest = %+v", kinds["Misty Rainforest"])
+		}
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		// A name not in the cube: an OCR misread.
+		sess := &Session{Players: map[string]*PlayerWork{
+			"a": pool(entry("Brainstorm", 2), entry("Misty Rainforest", 1), entry("Brainstrm", 1)),
+		}}
+		got := buildConsistencyReport(cl, sess, 1)
+		var unknown []Discrepancy
+		for _, d := range got.Discrepancies {
+			if d.Kind == "unknown" {
+				unknown = append(unknown, d)
+			}
+		}
+		if len(unknown) != 1 || unknown[0].CardName != "Brainstrm" || unknown[0].Pooled != 1 || unknown[0].Cube != 0 {
+			t.Fatalf("unknown = %+v", unknown)
+		}
+		// unknown sorts ahead of any missing/over.
+		if got.Discrepancies[0].Kind != "unknown" {
+			t.Fatalf("expected unknown first, got %+v", got.Discrepancies)
+		}
+	})
+
+	t.Run("captures attach to over and unknown, not missing", func(t *testing.T) {
+		// Brainstorm over-counted (3 of 2), Brainstrm a misread unknown, Misty
+		// Rainforest fully pooled. The boxes behind the bad names should attach.
+		sess := &Session{Players: map[string]*PlayerWork{
+			"a": {
+				PoolEntries: []PoolEntry{entry("Brainstorm", 3), entry("Misty Rainforest", 1), entry("Brainstrm", 1)},
+				Boxes: map[string][]Box{
+					"a/checkin-1.jpg": {
+						{ID: "b1", Chosen: "Brainstorm", Status: "high"},
+						{ID: "b2", Chosen: "Brainstrm", Status: "low"},
+						{ID: "b3", Chosen: "Misty Rainforest", Status: "high"},
+						{ID: "b4", Chosen: "", Status: "unmatched"},
+					},
+					"a/checkout-1.jpg": {
+						{ID: "b5", Chosen: "Brainstorm", Status: "high"},
+					},
+				},
+			},
+		}}
+		got := buildConsistencyReport(cl, sess, 1)
+		byName := map[string]Discrepancy{}
+		for _, d := range got.Discrepancies {
+			byName[d.CardName] = d
+		}
+		// Brainstorm boxes (b1 on check-in, b5 on check-out) both attach.
+		over := byName["Brainstorm"]
+		if over.Kind != "over" || len(over.Captures) != 2 {
+			t.Fatalf("Brainstorm captures = %+v", over)
+		}
+		ids := map[string]bool{}
+		for _, c := range over.Captures {
+			if c.Player != "a" {
+				t.Fatalf("capture player = %q, want a", c.Player)
+			}
+			ids[c.BoxID] = true
+		}
+		if !ids["b1"] || !ids["b5"] {
+			t.Fatalf("Brainstorm captures missing boxes: %+v", over.Captures)
+		}
+		// The misread attaches its single box.
+		unknown := byName["Brainstrm"]
+		if unknown.Kind != "unknown" || len(unknown.Captures) != 1 || unknown.Captures[0].BoxID != "b2" {
+			t.Fatalf("Brainstrm captures = %+v", unknown)
+		}
+		// Misty Rainforest is clean, so it isn't a discrepancy and has no captures.
+		if _, ok := byName["Misty Rainforest"]; ok {
+			t.Fatalf("Misty Rainforest should not be a discrepancy: %+v", byName["Misty Rainforest"])
+		}
+	})
+
+	t.Run("basics excluded and case-insensitive", func(t *testing.T) {
+		clBasic := loadTestCube(t, `{"cards":[{"name":"Brainstorm"}]}`)
+		sess := &Session{Players: map[string]*PlayerWork{
+			"a": pool(entry("brainstorm", 1), entry("Island", 5), entry("Forest", 3)),
+		}}
+		got := buildConsistencyReport(clBasic, sess, 1)
+		if len(got.Discrepancies) != 0 {
+			t.Fatalf("basics/case should not create discrepancies, got %+v", got.Discrepancies)
+		}
+		if got.PoolTotal != 1 {
+			t.Fatalf("pool total should exclude basics, got %d", got.PoolTotal)
+		}
+	})
+}
+
+func TestConsistencyHandler(t *testing.T) {
+	root := t.TempDir()
+	draftID := "2026-01-17_evt_1"
+	cube := "polyverse"
+	writeFile(t, filepath.Join(root, cube, "2026-01-17", "cube-snapshot.json"),
+		`{"cards":[{"name":"Brainstorm"},{"name":"Brainstorm"},{"name":"Misty Rainforest"}]}`)
+	// Two players need img dirs so discoverPlayers reports them.
+	writeFile(t, filepath.Join(root, cube, draftID, "img", "p1", "checkin-1.jpg"), "x")
+	writeFile(t, filepath.Join(root, cube, draftID, "img", "p2", "checkin-1.jpg"), "x")
+
+	sess := &Session{DraftID: draftID, Players: map[string]*PlayerWork{
+		"p1": pool(entry("Brainstorm", 2), entry("Misty Rainforest", 1)),
+	}}
+	if err := sess.Save(root, cube); err != nil {
+		t.Fatal(err)
+	}
+
+	h := ConsistencyHandlerWithRoot(root)
+	r := reqWithCube(t, "GET", "/api/polyverse/ocr/drafts/"+draftID+"/consistency", cube)
+	r.SetPathValue("draft_id", draftID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var rep ConsistencyReport
+	if err := json.Unmarshal(w.Body.Bytes(), &rep); err != nil {
+		t.Fatal(err)
+	}
+	if rep.PlayersTotal != 2 || rep.PlayersCounted != 1 {
+		t.Fatalf("players: total=%d counted=%d", rep.PlayersTotal, rep.PlayersCounted)
+	}
+	// Brainstorm pooled fully (2/2), Misty Rainforest fully (1/1): clean so far.
+	if len(rep.Discrepancies) != 0 {
+		t.Fatalf("expected no discrepancies, got %+v", rep.Discrepancies)
+	}
+}

--- a/pkg/server/ocr/drafts.go
+++ b/pkg/server/ocr/drafts.go
@@ -135,6 +135,18 @@ func DraftsHandlerWithRoot(dataRoot string) http.Handler {
 					warned++
 				}
 			}
+			// Conflicts from the pool-vs-cube check, so the list can flag drafts
+			// with OCR errors. A missing cube list or session just means no
+			// conflicts to report rather than failing the whole listing.
+			conflicts := 0
+			if cl, err := loadCubeForDraft(dataRoot, cube, draftID); err == nil {
+				sess, err := LoadSession(dataRoot, cube, draftID)
+				if err != nil {
+					sess = &Session{Players: map[string]*PlayerWork{}}
+				}
+				conflicts = buildConsistencyReport(cl, sess, len(players)).Conflicts()
+			}
+
 			meta := readDraftMeta(dataRoot, cube, draftID)
 			summaries = append(summaries, DraftSummary{
 				DraftID:         draftID,
@@ -142,6 +154,7 @@ func DraftsHandlerWithRoot(dataRoot string) http.Handler {
 				Flight:          meta.Flight,
 				Players:         len(players),
 				Confirmed:       confirmed,
+				Conflicts:       conflicts,
 				ReconfirmNeeded: reconfirm,
 				Warnings:        warned,
 			})

--- a/pkg/server/ocr/drafts_test.go
+++ b/pkg/server/ocr/drafts_test.go
@@ -120,3 +120,37 @@ func TestDraftsHandlerListsDraftsWithImages(t *testing.T) {
 		t.Fatalf("flight = %q, want Saturday Morning", out.Drafts[0].Flight)
 	}
 }
+
+func TestDraftsHandlerReportsConflicts(t *testing.T) {
+	root := t.TempDir()
+	cube := "polyverse"
+	draftID := "2026-01-17_evt_1"
+	base := filepath.Join(root, cube, draftID)
+	writeFile(t, filepath.Join(base, "img", "p1", "checkin-1.jpg"), "x")
+	// Cube has 1x Brainstorm; the pool claims 2, an over-count conflict.
+	writeFile(t, filepath.Join(root, cube, "2026-01-17", "cube-snapshot.json"),
+		`{"cards":[{"name":"Brainstorm"}]}`)
+	sess := &Session{DraftID: draftID, Players: map[string]*PlayerWork{
+		"p1": pool(entry("Brainstorm", 2)),
+	}}
+	if err := sess.Save(root, cube); err != nil {
+		t.Fatal(err)
+	}
+
+	h := DraftsHandlerWithRoot(root)
+	r := reqWithCube(t, "GET", "/api/polyverse/ocr/drafts", cube)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var out struct {
+		Drafts []DraftSummary `json:"drafts"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Drafts) != 1 || out.Drafts[0].Conflicts != 1 {
+		t.Fatalf("drafts = %+v", out.Drafts)
+	}
+}

--- a/pkg/server/ocr/util.go
+++ b/pkg/server/ocr/util.go
@@ -4,12 +4,29 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+
+	"github.com/caseydavenport/cube-tools/pkg/types"
 )
 
 // validDraftID rejects empty ids and anything that could escape the data dir
 // (path separators or "..") - draft ids land directly in filesystem paths.
 func validDraftID(id string) bool {
 	return id != "" && !strings.ContainsAny(id, `/\`) && !strings.Contains(id, "..")
+}
+
+// loadCubeForDraft loads the cube list for a draft, preferring the snapshot for
+// the draft's date (the first 10 chars of the ID) and falling back to the
+// latest snapshot when that date has none.
+func loadCubeForDraft(dataRoot, cube, draftID string) (*types.Cube, error) {
+	date := ""
+	if len(draftID) >= 10 {
+		date = draftID[:10]
+	}
+	cl, err := types.LoadCubeList(types.LoadOptions{DataRoot: dataRoot, Cube: cube, Date: date})
+	if err != nil {
+		return types.LoadCubeList(types.LoadOptions{DataRoot: dataRoot, Cube: cube})
+	}
+	return cl, nil
 }
 
 // writeJSON encodes v as indented JSON to the response. Encode errors are


### PR DESCRIPTION
Adds the consistency endpoint (sums every player's pool against the cube list and flags over/missing/unknown discrepancies with the boxes behind each), and wires the conflict count into the draft list badge. Pulls the shared `loadCubeForDraft` helper into util.go so cards.go, the badge, and the report all use one code path.