### PR TITLE
server: add OCR background scan-all endpoint

### DIFF
--- a/pkg/server/ocr/scan.go
+++ b/pkg/server/ocr/scan.go
@@ -1,0 +1,279 @@
+package ocr
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+	"github.com/caseydavenport/cube-tools/pkg/server"
+)
+
+// scanWorkers bounds how many photos are detected at once. Detection is
+// CPU-heavy (OpenCV + tesseract), so a small pool keeps the box responsive
+// without thrashing.
+const scanWorkers = 3
+
+// scanState is a background scan's lifecycle: idle (no job for this draft),
+// running, or done.
+type scanState string
+
+const (
+	scanIdle    scanState = "idle"
+	scanRunning scanState = "running"
+	scanDone    scanState = "done"
+)
+
+// scanJob tracks a background "scan all photos" run for one draft. The operator
+// kicks it off from the draft's player list and walks away; the workspace reads
+// boxes from the session as usual once the job has filled them in.
+type scanJob struct {
+	mu sync.Mutex
+
+	state   scanState
+	total   int
+	done    int
+	current string
+	err     string
+}
+
+type scanStatus struct {
+	State   scanState `json:"state"`
+	Total   int       `json:"total"`
+	Done    int       `json:"done"`
+	Current string    `json:"current,omitempty"`
+	Error   string    `json:"error,omitempty"`
+}
+
+func (j *scanJob) status() scanStatus {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return scanStatus{State: j.state, Total: j.total, Done: j.done, Current: j.current, Error: j.err}
+}
+
+// scanJobs holds the live (or just-finished) job per draft. A finished job is
+// kept so the UI can read a "done" status right after a run, but finished jobs
+// are pruned the next time any scan starts so the map can't grow without bound.
+var (
+	scanJobsMu sync.Mutex
+	scanJobs   = map[string]*scanJob{}
+)
+
+func scanKey(cube, draftID string) string { return cube + "/" + draftID }
+
+// scanItem is one photo to detect, tagged with the player it belongs to and
+// whether it's a deck photo (so the boxes land in the right session map).
+type scanItem struct {
+	player string
+	photo  string
+	deck   bool
+}
+
+// buildScanWorklist lists every pool and deck photo across all players that has
+// no boxes yet. Photos already scanned or hand-corrected are skipped, so the
+// scan is idempotent and never clobbers existing work.
+func buildScanWorklist(dataRoot, cube, draftID string) ([]scanItem, error) {
+	players, err := discoverPlayers(dataRoot, cube, draftID)
+	if err != nil {
+		return nil, err
+	}
+	sess, err := LoadSession(dataRoot, cube, draftID)
+	if err != nil {
+		sess = &Session{Players: map[string]*PlayerWork{}}
+	}
+
+	var items []scanItem
+	for _, p := range players {
+		pw := sess.Players[p.ID]
+		poolPhotos := append(append([]string{}, p.Photos.Checkin...), p.Photos.Checkout...)
+		for _, ph := range poolPhotos {
+			if pw != nil && len(pw.Boxes[ph]) > 0 {
+				continue
+			}
+			items = append(items, scanItem{player: p.ID, photo: ph, deck: false})
+		}
+		for _, ph := range p.Photos.Deck {
+			if pw != nil && len(pw.DeckBoxes[ph]) > 0 {
+				continue
+			}
+			items = append(items, scanItem{player: p.ID, photo: ph, deck: true})
+		}
+	}
+	return items, nil
+}
+
+func ScanStartHandler(det Detector) http.Handler { return ScanStartHandlerWithRoot(det, "data") }
+
+func ScanStartHandlerWithRoot(det Detector, dataRoot string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		draftID := r.PathValue("draft_id")
+		if cube == "" || !validDraftID(draftID) {
+			http.NotFound(rw, r)
+			return
+		}
+		key := scanKey(cube, draftID)
+
+		scanJobsMu.Lock()
+		// A scan is already running for this draft: report it rather than
+		// starting a second one that would race on the same session file.
+		if j, ok := scanJobs[key]; ok && j.status().State == scanRunning {
+			scanJobsMu.Unlock()
+			writeJSON(rw, j.status())
+			return
+		}
+		// Drop finished jobs (this draft's and any others') so the map only ever
+		// holds the running scans plus the one we're about to start.
+		for k, j := range scanJobs {
+			if j.status().State != scanRunning {
+				delete(scanJobs, k)
+			}
+		}
+		items, err := buildScanWorklist(dataRoot, cube, draftID)
+		if err != nil {
+			scanJobsMu.Unlock()
+			http.Error(rw, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		job := &scanJob{state: scanRunning, total: len(items)}
+		scanJobs[key] = job
+		scanJobsMu.Unlock()
+
+		go runScan(det, dataRoot, cube, draftID, items, job)
+		writeJSON(rw, job.status())
+	})
+}
+
+func ScanStatusHandler() http.Handler { return ScanStatusHandlerWithRoot("data") }
+
+func ScanStatusHandlerWithRoot(_ string) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cube := server.CubeFromRequest(r)
+		draftID := r.PathValue("draft_id")
+		if cube == "" || !validDraftID(draftID) {
+			http.NotFound(rw, r)
+			return
+		}
+		scanJobsMu.Lock()
+		j := scanJobs[scanKey(cube, draftID)]
+		scanJobsMu.Unlock()
+		if j == nil {
+			writeJSON(rw, scanStatus{State: scanIdle})
+			return
+		}
+		writeJSON(rw, j.status())
+	})
+}
+
+func runScan(det Detector, dataRoot, cube, draftID string, items []scanItem, job *scanJob) {
+	workers := min(scanWorkers, len(items))
+	ch := make(chan scanItem)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for it := range ch {
+				scanOne(det, dataRoot, cube, draftID, it, job)
+			}
+		}()
+	}
+	for _, it := range items {
+		ch <- it
+	}
+	close(ch)
+	wg.Wait()
+
+	job.mu.Lock()
+	job.state = scanDone
+	job.current = ""
+	job.mu.Unlock()
+}
+
+func scanOne(det Detector, dataRoot, cube, draftID string, it scanItem, job *scanJob) {
+	job.mu.Lock()
+	job.current = it.photo
+	job.mu.Unlock()
+	defer func() {
+		job.mu.Lock()
+		job.done++
+		job.mu.Unlock()
+	}()
+
+	abs, cl, ok := resolvePhoto(dataRoot, cube, it.photo)
+	if !ok {
+		return
+	}
+	results, err := det.DetectPhoto(abs, cl)
+	if err != nil {
+		// Leave this photo empty so the operator can scan it by hand later, but
+		// surface the first failure in the job status and the log.
+		logrus.WithError(err).WithField("photo", it.photo).Warn("Background scan failed to detect photo")
+		job.mu.Lock()
+		if job.err == "" {
+			job.err = err.Error()
+		}
+		job.mu.Unlock()
+		return
+	}
+	boxes := make([]Box, 0, len(results))
+	for i, res := range results {
+		boxes = append(boxes, resultToBox(it.photo, i, res))
+	}
+	writeScannedBoxes(dataRoot, cube, draftID, it, boxes)
+}
+
+// resultToBox mirrors the client's linesToBoxes so background-scanned boxes are
+// identical to ones produced by the per-photo Scan button.
+func resultToBox(photo string, i int, r ocrpkg.MatchResult) Box {
+	jl := toLineJSON(r)
+	return Box{
+		ID:         fmt.Sprintf("%s:%d", photo, i),
+		Bbox:       jl.Bbox,
+		Status:     jl.Band,
+		Chosen:     jl.Chosen,
+		Candidates: jl.Candidates,
+	}
+}
+
+// writeScannedBoxes merges one photo's boxes into the session. It takes the same
+// lock as the client autosave and re-checks that the photo is still empty, so a
+// player the operator opened and started correcting mid-scan is never clobbered.
+func writeScannedBoxes(dataRoot, cube, draftID string, it scanItem, boxes []Box) {
+	sessionSaveMu.Lock()
+	defer sessionSaveMu.Unlock()
+
+	s, err := LoadSession(dataRoot, cube, draftID)
+	if err != nil {
+		logrus.WithError(err).WithField("draft", draftID).Warn("Background scan could not load session")
+		return
+	}
+	s.DraftID = draftID
+	pw := s.Players[it.player]
+	if pw == nil {
+		pw = &PlayerWork{}
+		s.Players[it.player] = pw
+	}
+	if it.deck {
+		if pw.DeckBoxes == nil {
+			pw.DeckBoxes = map[string][]Box{}
+		}
+		if len(pw.DeckBoxes[it.photo]) > 0 {
+			return
+		}
+		pw.DeckBoxes[it.photo] = boxes
+	} else {
+		if pw.Boxes == nil {
+			pw.Boxes = map[string][]Box{}
+		}
+		if len(pw.Boxes[it.photo]) > 0 {
+			return
+		}
+		pw.Boxes[it.photo] = boxes
+	}
+	if err := s.Save(dataRoot, cube); err != nil {
+		logrus.WithError(err).WithField("draft", draftID).Warn("Background scan could not save session")
+	}
+}

--- a/pkg/server/ocr/scan_test.go
+++ b/pkg/server/ocr/scan_test.go
@@ -1,0 +1,133 @@
+package ocr
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ocrpkg "github.com/caseydavenport/cube-tools/pkg/ocr"
+	"github.com/caseydavenport/cube-tools/pkg/types"
+)
+
+// scanFakeDetector is stateless so the worker pool can call it concurrently
+// without racing on shared fields.
+type scanFakeDetector struct{}
+
+func (scanFakeDetector) DetectPhoto(_ string, _ *types.Cube) ([]ocrpkg.MatchResult, error) {
+	return []ocrpkg.MatchResult{
+		{
+			DetectedText: "Brainstom",
+			Band:         ocrpkg.ConfidenceHigh,
+			Candidates:   []ocrpkg.Candidate{{Name: "Brainstorm", Score: 0.92}},
+			Bbox:         ocrpkg.Bbox{X: 5, Y: 6, Width: 7, Height: 8},
+		},
+	}, nil
+}
+
+func (scanFakeDetector) MatchRegion(_ string, box ocrpkg.Bbox, _ *types.Cube) (ocrpkg.MatchResult, error) {
+	return ocrpkg.MatchResult{Bbox: box}, nil
+}
+
+func startScan(t *testing.T, root, draftID string) {
+	t.Helper()
+	h := ScanStartHandlerWithRoot(scanFakeDetector{}, root)
+	r := reqWithCube(t, "POST", "/api/polyverse/ocr/drafts/"+draftID+"/scan", "polyverse")
+	r.SetPathValue("draft_id", draftID)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("scan start status = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func waitScanDone(t *testing.T, draftID string) scanStatus {
+	t.Helper()
+	for range 200 {
+		scanJobsMu.Lock()
+		j := scanJobs[scanKey("polyverse", draftID)]
+		scanJobsMu.Unlock()
+		if j != nil {
+			if st := j.status(); st.State == scanDone {
+				return st
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("scan did not finish in time")
+	return scanStatus{}
+}
+
+func TestScanFillsSession(t *testing.T) {
+	root := t.TempDir()
+	setupCube(t, root)
+	draftID := "2026-01-17_evt_1"
+	checkin := draftID + "/img/p3/checkin-1.jpg"
+	deck := draftID + "/img/p3/deck-1.jpg"
+	writeFile(t, filepath.Join(root, "polyverse", checkin), "x")
+	writeFile(t, filepath.Join(root, "polyverse", deck), "x")
+
+	startScan(t, root, draftID)
+	st := waitScanDone(t, draftID)
+	if st.Total != 2 {
+		t.Fatalf("total = %d, want 2", st.Total)
+	}
+
+	s, err := LoadSession(root, "polyverse", draftID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pw := s.Players["p3"]
+	if pw == nil {
+		t.Fatalf("p3 has no work: %+v", s.Players)
+	}
+	if len(pw.Boxes[checkin]) != 1 || pw.Boxes[checkin][0].Chosen != "Brainstorm" {
+		t.Fatalf("pool boxes = %+v", pw.Boxes)
+	}
+	if len(pw.DeckBoxes[deck]) != 1 || pw.DeckBoxes[deck][0].Chosen != "Brainstorm" {
+		t.Fatalf("deck boxes = %+v", pw.DeckBoxes)
+	}
+}
+
+// A photo that already has boxes (scanned or hand-corrected) must be left alone:
+// the worklist skips it, so a re-run never re-detects or clobbers it.
+func TestScanSkipsExistingBoxes(t *testing.T) {
+	root := t.TempDir()
+	setupCube(t, root)
+	draftID := "2026-01-17_evt_1"
+	checkin := draftID + "/img/p3/checkin-1.jpg"
+	deck := draftID + "/img/p3/deck-1.jpg"
+	writeFile(t, filepath.Join(root, "polyverse", checkin), "x")
+	writeFile(t, filepath.Join(root, "polyverse", deck), "x")
+
+	// Seed the pool photo with a hand-corrected box.
+	manual := Box{ID: checkin + ":0", Status: "high", Chosen: "Ponder", Bbox: ocrpkg.Bbox{X: 1, Y: 2, Width: 3, Height: 4}}
+	seed := &Session{
+		DraftID: draftID,
+		Players: map[string]*PlayerWork{
+			"p3": {Boxes: map[string][]Box{checkin: {manual}}},
+		},
+	}
+	if err := seed.Save(root, "polyverse"); err != nil {
+		t.Fatal(err)
+	}
+
+	startScan(t, root, draftID)
+	st := waitScanDone(t, draftID)
+	// Only the deck photo is unscanned, so the worklist should be just that one.
+	if st.Total != 1 {
+		t.Fatalf("total = %d, want 1 (only the unscanned deck photo)", st.Total)
+	}
+
+	s, err := LoadSession(root, "polyverse", draftID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pw := s.Players["p3"]
+	if len(pw.Boxes[checkin]) != 1 || pw.Boxes[checkin][0].Chosen != "Ponder" {
+		t.Fatalf("hand-corrected box was overwritten: %+v", pw.Boxes[checkin])
+	}
+	if len(pw.DeckBoxes[deck]) != 1 {
+		t.Fatalf("deck photo not scanned: %+v", pw.DeckBoxes)
+	}
+}


### PR DESCRIPTION
Adds a background scan-all job that detects every unscanned pool and deck photo in a draft, filling the session as a worker pool runs. Skips photos that already have boxes so it never clobbers hand-corrected work, and prunes finished jobs on each start so the job map stays bounded.