### PR TITLE
server: containerize the OCR server

### DIFF
--- a/Dockerfile.server-ocr
+++ b/Dockerfile.server-ocr
@@ -1,0 +1,40 @@
+# OCR-enabled server. Unlike Dockerfile.server (a static CGO_ENABLED=0 binary in
+# FROM scratch), the OCR build links OpenCV via gocv and shells out to the
+# tesseract CLI, so it needs real shared libraries at runtime. Built separately
+# to keep the default server image small and OpenCV/tesseract-free.
+
+# Build stage: full OpenCV dev headers + Go toolchain to compile -tags ocr_cv.
+FROM ubuntu:24.04 AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	golang-go \
+	g++ \
+	libopencv-dev \
+	pkg-config \
+	ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+WORKDIR /code
+COPY . .
+RUN CGO_ENABLED=1 go build -tags ocr_cv -o /server-ocr ./cmd/server/server.go
+
+# Runtime stage: the OpenCV 4.6 runtime libraries the gocv binding links (the
+# whole module suite, not just core), plus the tesseract CLI. The engine invokes
+# `tesseract` as a subprocess, so it needs the binary, not libtesseract.
+FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	libopencv-calib3d406t64 \
+	libopencv-core406t64 \
+	libopencv-dnn406t64 \
+	libopencv-features2d406t64 \
+	libopencv-flann406t64 \
+	libopencv-highgui406t64 \
+	libopencv-imgcodecs406t64 \
+	libopencv-imgproc406t64 \
+	libopencv-objdetect406t64 \
+	libopencv-photo406t64 \
+	libopencv-video406t64 \
+	libopencv-videoio406t64 \
+	tesseract-ocr \
+	&& rm -rf /var/lib/apt/lists/*
+WORKDIR /code
+COPY --from=build /server-ocr /server-ocr
+CMD ["/server-ocr"]

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,19 @@ run-server: .server.created
 		-v $(PWD):/code \
 		caseydavenport/cube-tools-server
 
+# OCR server image. The Dockerfile builds the -tags ocr_cv binary itself (it
+# bundles OpenCV + tesseract), so this depends on the sources, not bin/server-ocr.
+server-ocr: .server-ocr.created
+.server-ocr.created: $(GO_FILES) Dockerfile.server-ocr
+	docker build -t caseydavenport/cube-tools-server-ocr -f Dockerfile.server-ocr .
+	touch $@
+
+run-server-ocr: .server-ocr.created
+	-docker rm -f cube-tools-server-ocr
+	docker run --rm --name=cube-tools-server-ocr --detach -p 8888:8888 \
+		-v $(PWD):/code \
+		caseydavenport/cube-tools-server-ocr
+
 ###################
 # Parse CLI build
 ###################


### PR DESCRIPTION
Adds a multi-stage Dockerfile.server-ocr: the build stage compiles the `-tags ocr_cv` binary against OpenCV 4.6, and the runtime stage carries just the OpenCV runtime libs + the tesseract CLI (kept separate so the default server image stays small and OpenCV-free).

New `make server-ocr`/`run-server-ocr` targets mirror the existing `server`/`run-server` ones.