### PR TITLE
ui: add OCR import page and wire up route and nav

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { CubeProvider } from './contexts/CubeContext.js';
 import Landing from './pages/Landing.js';
 import Overview from './pages/Overview.js';
+import OCRImport from './pages/OCRImport.js';
 
 import "./styles.css";
 
@@ -68,6 +69,7 @@ export default function Main() {
               onMatchUpdated={onMatchUpdated}
             />
           } />
+          <Route path='import' element={<OCRImport />} />
         </Route>
       </Routes>
     </Router>

--- a/ui/src/components/navbar.js
+++ b/ui/src/components/navbar.js
@@ -48,6 +48,7 @@ const Navbar = () => {
           <li><NavLink to={`/${cube}/colors`} className={({ isActive }) => isActive ? "active" : ""}>Colors</NavLink></li>
           <li><NavLink to={`/${cube}/types`} className={({ isActive }) => isActive ? "active" : ""}>Types</NavLink></li>
           <li><NavLink to={`/${cube}/decklists`} className={({ isActive }) => isActive ? "active" : ""}>Decklists</NavLink></li>
+          <li><NavLink to={`/${cube}/import`} className={({ isActive }) => isActive ? "active" : ""}>Import</NavLink></li>
           <li><NavLink to={`/${cube}/deckstats`} className={({ isActive }) => isActive ? "active" : ""}>Deck Stats</NavLink></li>
           <li><NavLink to={`/${cube}/drafts`} className={({ isActive }) => isActive ? "active" : ""}>Drafts</NavLink></li>
           <li><NavLink to={`/${cube}/players`} className={({ isActive }) => isActive ? "active" : ""}>Players</NavLink></li>

--- a/ui/src/pages/OCRImport.js
+++ b/ui/src/pages/OCRImport.js
@@ -1,0 +1,347 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useCube } from '../contexts/CubeContext.js';
+import { LoadOCRDrafts, LoadOCRDraft, StartDraftScan, GetDraftScan, LoadOCRConsistency, LoadOCRCards, LoadOCRSession, SaveOCRSession } from '../utils/OCRFetch.js';
+import { Snippet, Autocomplete } from './PoolList.js';
+import { deriveList } from '../utils/Reconcile.js';
+import { PlayerWorkspace } from './PlayerWorkspace.js';
+
+// OCRImport is the top-level OCR screen. It walks three views: pick a draft,
+// then a player (with the scan-all control and the pool-vs-cube consistency
+// check), then that player's reconciliation workspace.
+export default function OCRImport() {
+  const cube = useCube();
+
+  // drafts is the list view; draft is the open DraftDetail; playerId selects a
+  // player within it. scan tracks the background photo scan, consistency the
+  // pool-vs-cube check, and cards the cube list used for rename search.
+  const [drafts, setDrafts] = useState([]);
+  const [draft, setDraft] = useState(null);
+  const [playerId, setPlayerId] = useState(null);
+  const [scan, setScan] = useState(null);
+  const [consistency, setConsistency] = useState(null);
+  const [cards, setCards] = useState([]);
+
+  useEffect(() => { LoadOCRDrafts(cube).then(setDrafts); }, [cube]);
+
+  // Recompute the pool-vs-cube consistency check. Called when the open draft
+  // changes (including the reload after a scan finishes) and after each fix.
+  const reloadConsistency = useCallback(() => {
+    if (!draft) return Promise.resolve();
+    return LoadOCRConsistency(cube, draft.draft_id)
+      .then(setConsistency)
+      .catch(() => setConsistency(null));
+  }, [cube, draft]);
+
+  useEffect(() => {
+    if (!draft) { setConsistency(null); setCards([]); return; }
+    let alive = true;
+    LoadOCRConsistency(cube, draft.draft_id)
+      .then(c => { if (alive) setConsistency(c); })
+      .catch(() => { if (alive) setConsistency(null); });
+    LoadOCRCards(cube, draft.draft_id).then(c => { if (alive) setCards(c); });
+    return () => { alive = false; };
+  }, [cube, draft]);
+
+  // Pick up any scan already running for this draft (e.g. started before a
+  // reload) so the progress UI reflects it.
+  useEffect(() => {
+    if (!draft) { setScan(null); return; }
+    let alive = true;
+    GetDraftScan(cube, draft.draft_id).then(s => { if (alive) setScan(s); });
+    return () => { alive = false; };
+  }, [cube, draft]);
+
+  // While a scan runs, poll for progress. When it finishes, reload the draft so
+  // the per-player status dots reflect the freshly scanned boxes.
+  useEffect(() => {
+    if (!draft || !scan || scan.state !== "running") return;
+    const t = setTimeout(async () => {
+      const s = await GetDraftScan(cube, draft.draft_id);
+      setScan(s);
+      if (s.state !== "running") setDraft(await LoadOCRDraft(cube, draft.draft_id));
+    }, 1500);
+    return () => clearTimeout(t);
+  }, [cube, draft, scan]);
+
+  async function openDraft(id) {
+    const d = await LoadOCRDraft(cube, id);
+    setDraft(d);
+    setPlayerId(null);
+  }
+
+  async function startScan() {
+    setScan(await StartDraftScan(cube, draft.draft_id));
+  }
+
+  if (draft && playerId) {
+    const player = draft.players.find(p => p.id === playerId);
+    return (
+      <div className="ocr-import wide">
+        <button className="ocr-back" onClick={() => setPlayerId(null)}>&larr; Players</button>
+        <PlayerWorkspace cube={cube} draft={draft} player={player} />
+      </div>
+    );
+  }
+
+  if (draft) {
+    return (
+      <div className="ocr-import">
+        <button className="ocr-back" onClick={() => setDraft(null)}>&larr; Drafts</button>
+        <h2 className="ocr-title">
+          {draft.event_name || draft.draft_id}
+          {draft.flight && <span className="ocr-title-flight">{draft.flight}</span>}
+        </h2>
+        <div className="ocr-scan-bar">
+          <button className="ocr-scan-all" onClick={startScan} disabled={scan && scan.state === "running"}>
+            {scan && scan.state === "running" ? "Scanning…" : "Scan all photos"}
+          </button>
+          {scan && scan.state === "running" && (
+            <span className="ocr-scan-progress">
+              <span className="ocr-scan-bar-track">
+                <span className="ocr-scan-bar-fill" style={{ width: `${scan.total ? (scan.done / scan.total) * 100 : 0}%` }} />
+              </span>
+              {scan.done}/{scan.total}{scan.current ? ` · ${scan.current.split("/").pop()}` : ""}
+            </span>
+          )}
+          {scan && scan.state === "done" && scan.total > 0 && (
+            <span className="ocr-scan-progress">Scanned {scan.total} photo{scan.total === 1 ? "" : "s"}</span>
+          )}
+          {scan && scan.error && <span className="ocr-scan-error">some photos failed: {scan.error}</span>}
+        </div>
+        {consistency && (
+          <ConsistencyPanel report={consistency} cube={cube} draftId={draft.draft_id}
+            cards={cards} onFixed={reloadConsistency} />
+        )}
+        <ul className="ocr-card-list">
+          {draft.players.map(p => {
+            const pool = (p.photos.checkin || []).length + (p.photos.checkout || []).length;
+            const deck = (p.photos.deck || []).length;
+            return (
+              <li key={p.id}>
+                <button className="ocr-card-row" onClick={() => setPlayerId(p.id)}>
+                  <span className="ocr-card-title">
+                    <span className={`ocr-status-dot ${p.status || 'unstarted'}`} />
+                    {p.id}
+                  </span>
+                  <span className="ocr-badges">
+                    {p.needs_reconfirm && (
+                      <span className="ocr-badge reconfirm" title="deck is stale - re-confirm to write the corrected pool">reconfirm</span>
+                    )}
+                    {p.warnings && p.warnings.length > 0 && (
+                      <span className="ocr-badge warn" title={p.warnings.join("\n")}>
+                        {p.warnings.length} warning{p.warnings.length === 1 ? "" : "s"}
+                      </span>
+                    )}
+                    <span className="ocr-meta">{pool} pool · {deck} deck</span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ocr-import">
+      <h2 className="ocr-title">Import a draft</h2>
+      <ul className="ocr-card-list">
+        {drafts.map(d => {
+          const done = d.players > 0 && d.confirmed >= d.players;
+          return (
+            <li key={d.draft_id}>
+              <button className="ocr-card-row" onClick={() => openDraft(d.draft_id)}>
+                <span className="ocr-card-head">
+                  <span className="ocr-card-title">{d.event_name || d.draft_id}</span>
+                  {d.flight && <span className="ocr-meta">{d.flight}</span>}
+                </span>
+                <span className="ocr-badges">
+                  {d.conflicts > 0 && (
+                    <span className="ocr-badge conflict" title="pool does not match the cube">
+                      {d.conflicts} conflict{d.conflicts === 1 ? "" : "s"}
+                    </span>
+                  )}
+                  {d.reconfirm_needed > 0 && (
+                    <span className="ocr-badge reconfirm" title="confirmed decks are stale and need re-confirming">
+                      {d.reconfirm_needed} reconfirm
+                    </span>
+                  )}
+                  {d.warnings > 0 && (
+                    <span className="ocr-badge warn" title="confirmed decks have cross-check warnings">
+                      {d.warnings} warning{d.warnings === 1 ? "" : "s"}
+                    </span>
+                  )}
+                  <span className={`ocr-badge ${done ? "done" : ""}`}>{d.confirmed}/{d.players} done</span>
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+// applyCaptureFix reassigns or removes one pool box behind a discrepancy, then
+// re-derives the player's pool so the consistency check reflects the change.
+// The session merges per-player server-side, so we load the player's current
+// work, mutate the one box, and post the whole player back. newName === null
+// removes the box (a stray detection); otherwise it's a rename (status "high",
+// same as picking a name by hand in the workspace). An over-count is usually a
+// misread of a card that's "missing", so renaming the bad box to that missing
+// card fixes both at once.
+async function applyCaptureFix(cube, draftId, cap, newName) {
+  const sess = await LoadOCRSession(cube, draftId);
+  const pw = (sess.players && sess.players[cap.player]) || {};
+  const boxes = pw.boxes || {};
+  const photoBoxes = boxes[cap.photo] || [];
+  const nextPhoto = newName === null
+    ? photoBoxes.filter(b => b.id !== cap.box_id)
+    : photoBoxes.map(b => b.id === cap.box_id ? { ...b, chosen: newName, status: "high" } : b);
+  const newBoxes = { ...boxes, [cap.photo]: nextPhoto };
+  await SaveOCRSession(cube, draftId, {
+    draft_id: draftId,
+    players: { [cap.player]: {
+      ...pw,
+      status: pw.status || "in_progress",
+      boxes: newBoxes,
+      pool_entries: deriveList(newBoxes, pw.overrides || {}),
+      mainboard_entries: deriveList(pw.deck_boxes || {}, pw.deck_overrides || {}),
+    } },
+  });
+}
+
+// ConsistencyPanel summarizes the sum of every player's pool against the cube
+// list. A clean draft pools each cube card its full copy count, so "over"
+// (too many copies) and "unknown" (a name not in the cube) are real OCR errors
+// shown loudly. "Missing" is expected until every player is scanned, so it's
+// folded behind a toggle. Each error row expands to the pool boxes behind it,
+// where the operator can rename or drop the misread box to fix the count.
+function ConsistencyPanel({ report, cube, draftId, cards, onFixed }) {
+  const [showMissing, setShowMissing] = useState(false);
+  const discs = report.discrepancies || [];
+  const errors = discs.filter(d => d.kind === "over" || d.kind === "unknown");
+  const missing = discs.filter(d => d.kind === "missing");
+  const missingNames = missing.map(d => d.card_name);
+  const clean = errors.length === 0;
+  return (
+    <div className={`ocr-consistency ${clean ? "ok" : "warn"}`}>
+      <div className="ocr-consistency-head">
+        <span className="ocr-consistency-totals">
+          {report.pool_total} / {report.cube_total} cube cards pooled
+          <span className="ocr-consistency-players"> · {report.players_counted}/{report.players_total} players scanned</span>
+        </span>
+        {clean
+          ? <span className="ocr-consistency-flag ok">no conflicts</span>
+          : <span className="ocr-consistency-flag warn">{errors.length} to check</span>}
+      </div>
+      {errors.length > 0 && (
+        <ul className="ocr-consistency-list">
+          {errors.map(d => (
+            <DiscrepancyRow key={d.kind + d.card_name} disc={d} cube={cube} draftId={draftId}
+              cards={cards} missingNames={missingNames} onFixed={onFixed} />
+          ))}
+        </ul>
+      )}
+      {missing.length > 0 && (
+        <div className="ocr-consistency-missing">
+          <button onClick={() => setShowMissing(v => !v)}>
+            {showMissing ? "Hide" : "Show"} {missing.length} not yet pooled
+          </button>
+          {showMissing && (
+            <ul className="ocr-consistency-list">
+              {missing.map(d => (
+                <li key={d.card_name} className="ocr-disc missing">
+                  <span className="ocr-disc-name">{d.card_name}</span>
+                  <span className="ocr-disc-count">{d.pooled} / {d.cube}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// DiscrepancyRow is one over/unknown card. Clicking it expands to the pool boxes
+// (captures) that resolved to its name, each with a fix control.
+function DiscrepancyRow({ disc, cube, draftId, cards, missingNames, onFixed }) {
+  const [open, setOpen] = useState(false);
+  const captures = disc.captures || [];
+  return (
+    <li className={`ocr-disc ${disc.kind} ${open ? "open" : ""}`}>
+      <button className="ocr-disc-row" onClick={() => setOpen(v => !v)} disabled={captures.length === 0}>
+        <span className="ocr-disc-kind">{disc.kind === "over" ? "over" : "not in cube"}</span>
+        <span className="ocr-disc-name">{disc.card_name}</span>
+        <span className="ocr-disc-count">
+          {disc.kind === "over" ? `${disc.pooled} pooled, cube has ${disc.cube}` : `${disc.pooled} pooled`}
+        </span>
+        {captures.length > 0 && <span className="ocr-disc-toggle">{open ? "−" : "+"}</span>}
+      </button>
+      {open && (
+        <ul className="ocr-disc-captures">
+          {captures.map(cap => (
+            <CaptureFix key={cap.player + cap.photo + cap.box_id} cap={cap} cube={cube} draftId={draftId}
+              cards={cards} missingNames={missingNames} onFixed={onFixed} />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+// CaptureFix shows one pool box's cropped nameplate next to its current name and
+// lets the operator correct it: rename to a missing card (the likely fix for an
+// over-count), to one of the box's own OCR candidates, to any card by search, or
+// drop the box if it's a stray detection.
+function CaptureFix({ cap, cube, draftId, cards, missingNames, onFixed }) {
+  const [busy, setBusy] = useState(false);
+  const source = { photo: cap.photo, box: cap.bbox };
+  const cand = (cap.candidates || []).filter(c => c.name !== cap.chosen).slice(0, 3);
+
+  const fix = async newName => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await applyCaptureFix(cube, draftId, cap, newName);
+      await onFixed();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <li className={`ocr-capture ${busy ? "busy" : ""}`}>
+      <div className="ocr-capture-top">
+        <Snippet cube={cube} source={source} w={264} h={56} />
+        <span className="ocr-capture-meta">
+          <span className="ocr-capture-player">{cap.player}</span>
+          <span className="ocr-capture-name">{cap.chosen}</span>
+        </span>
+        <button className="ocr-capture-remove" onClick={() => fix(null)} disabled={busy} title="drop this detection">remove</button>
+      </div>
+      <div className="ocr-capture-fix">
+        {missingNames.length > 0 && (
+          <div className="ocr-capture-missing">
+            <span className="ocr-capture-label">missing:</span>
+            {missingNames.slice(0, 6).map(name => (
+              <button key={name} onClick={() => fix(name)} disabled={busy}>{name}</button>
+            ))}
+          </div>
+        )}
+        {cand.length > 0 && (
+          <div className="ocr-cand">
+            {cand.map(c => (
+              <button key={c.name} onClick={() => fix(c.name)} disabled={busy}>
+                {c.name}{c.score != null ? ` (${c.score.toFixed(2)})` : ""}
+              </button>
+            ))}
+          </div>
+        )}
+        <Autocomplete cards={cards} onPick={fix} placeholder="rename to…" />
+      </div>
+    </li>
+  );
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -691,3 +691,338 @@ table {
 .search-pill-deck {
   color: var(--secondary);
 }
+
+/* ── OCR import: draft / player navigation ────────────────────────── */
+.ocr-import { max-width: 940px; padding: 0 24px; }
+.ocr-import.wide { max-width: none; }
+.ocr-title { margin: 4px 0 18px; font-size: 1.4em; letter-spacing: 0.01em; }
+.ocr-scan-bar { display: flex; align-items: center; gap: 12px; margin: -8px 0 16px; }
+.ocr-scan-all { background: var(--primary); color: #0f172a; border: none; border-radius: 6px; padding: 7px 14px; font-weight: 600; cursor: pointer; }
+.ocr-scan-all:disabled { opacity: 0.6; cursor: default; }
+.ocr-scan-progress { display: flex; align-items: center; gap: 10px; color: var(--text-muted); font-size: 13px; font-variant-numeric: tabular-nums; }
+.ocr-scan-bar-track { display: inline-block; width: 140px; height: 6px; background: var(--border); border-radius: 3px; overflow: hidden; }
+.ocr-scan-bar-fill { display: block; height: 100%; background: var(--primary); transition: width 0.3s ease; }
+.ocr-scan-error { color: var(--danger); font-size: 13px; }
+
+/* Pool-vs-cube consistency panel on the draft view. */
+.ocr-consistency {
+  border: 1px solid var(--border); border-radius: 10px;
+  background: var(--card-background); padding: 12px 16px; margin: 0 0 16px;
+}
+.ocr-consistency.warn { border-color: rgba(239,68,68,0.45); }
+.ocr-consistency-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.ocr-consistency-totals { font-size: 0.92em; font-variant-numeric: tabular-nums; }
+.ocr-consistency-players { color: var(--text-muted); }
+.ocr-consistency-flag { font-size: 0.8em; padding: 3px 11px; border-radius: 999px; white-space: nowrap; }
+.ocr-consistency-flag.ok { background: rgba(34,197,94,0.15); border: 1px solid rgba(34,197,94,0.4); color: #22c55e; }
+.ocr-consistency-flag.warn { background: rgba(239,68,68,0.15); border: 1px solid rgba(239,68,68,0.45); color: var(--danger); }
+.ocr-consistency-list { list-style: none; padding: 0; margin: 10px 0 0; display: flex; flex-direction: column; gap: 6px; }
+.ocr-disc {
+  display: flex; align-items: baseline; gap: 10px; font-size: 0.9em;
+  font-variant-numeric: tabular-nums;
+}
+.ocr-disc-kind {
+  flex: none; width: 80px; font-size: 0.78em; font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.ocr-disc.over .ocr-disc-kind, .ocr-disc.unknown .ocr-disc-kind { color: var(--danger); }
+.ocr-disc-name { font-weight: 600; }
+.ocr-disc-count { color: var(--text-muted); }
+.ocr-disc.missing .ocr-disc-name { font-weight: 400; }
+.ocr-consistency-missing { margin-top: 10px; }
+.ocr-consistency-missing > button {
+  background: none; border: none; color: var(--text-muted); cursor: pointer;
+  font-size: 0.85em; padding: 0; text-decoration: underline;
+}
+.ocr-consistency-missing > button:hover { color: var(--primary); }
+
+/* Over/unknown rows are expandable, so they stack the clickable summary above
+   the captures rather than laying out inline like the flat missing rows. */
+.ocr-disc.over, .ocr-disc.unknown { flex-direction: column; align-items: stretch; gap: 0; }
+.ocr-disc-row {
+  display: flex; align-items: baseline; gap: 10px; width: 100%;
+  background: none; border: none; padding: 4px 0; margin: 0; cursor: pointer;
+  text-align: left; color: inherit; font: inherit;
+}
+.ocr-disc-row:disabled { cursor: default; }
+.ocr-disc-toggle { margin-left: auto; color: var(--text-muted); font-weight: 600; }
+.ocr-disc-captures {
+  list-style: none; padding: 8px 0 4px; margin: 0;
+  display: flex; flex-direction: column; gap: 10px;
+}
+.ocr-capture {
+  border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px;
+  background: var(--page-background);
+}
+.ocr-capture.busy { opacity: 0.5; pointer-events: none; }
+.ocr-capture-top { display: flex; align-items: center; gap: 12px; }
+.ocr-capture-meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.ocr-capture-player { font-size: 0.75em; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.03em; }
+.ocr-capture-name { font-weight: 600; }
+.ocr-capture-remove {
+  margin-left: auto; flex: none; background: none; border: 1px solid var(--border);
+  border-radius: 6px; color: var(--text-muted); padding: 3px 10px; cursor: pointer; font-size: 0.8em;
+}
+.ocr-capture-remove:hover { border-color: var(--danger); color: var(--danger); }
+.ocr-capture-fix { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
+.ocr-capture-missing { display: flex; flex-wrap: wrap; align-items: center; gap: 4px; }
+.ocr-capture-label { font-size: 0.78em; color: var(--text-muted); margin-right: 2px; }
+.ocr-capture-missing button {
+  background: rgba(34,197,94,0.12); border: 1px solid rgba(34,197,94,0.35); border-radius: 6px;
+  color: #22c55e; padding: 2px 8px; cursor: pointer; font-size: 0.82em;
+}
+.ocr-capture-missing button:hover { background: rgba(34,197,94,0.22); }
+
+.ocr-back {
+  display: inline-flex; align-items: center; gap: 6px; margin-bottom: 18px;
+  background: var(--card-background); border: 1px solid var(--border); border-radius: 8px;
+  color: var(--text-muted); padding: 6px 14px; cursor: pointer; font-size: 0.9em;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.ocr-back:hover { color: var(--primary); border-color: var(--primary); }
+
+.ocr-card-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.ocr-card-row {
+  width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  background: var(--card-background); border: 1px solid var(--border); border-radius: 10px;
+  color: inherit; padding: 14px 18px; cursor: pointer; text-align: left;
+  transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.ocr-card-row:hover {
+  border-color: var(--primary); transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(0,0,0,0.3);
+}
+.ocr-card-head { display: flex; flex-direction: column; align-items: flex-start; gap: 3px; min-width: 0; }
+.ocr-card-title { display: inline-flex; align-items: center; gap: 9px; font-weight: 600; font-size: 1.02em; }
+.ocr-title-flight { color: var(--text-muted); font-weight: 400; font-size: 0.7em; margin-left: 10px; }
+.ocr-meta { color: var(--text-muted); font-size: 0.85em; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.ocr-badge {
+  font-size: 0.8em; font-variant-numeric: tabular-nums; padding: 3px 11px; border-radius: 999px;
+  background: var(--page-background); border: 1px solid var(--border); color: var(--text-muted); white-space: nowrap;
+}
+.ocr-badge.done { background: rgba(34,197,94,0.15); border-color: rgba(34,197,94,0.4); color: #22c55e; }
+.ocr-badges { display: inline-flex; align-items: center; gap: 8px; }
+.ocr-badge.conflict { background: rgba(239,68,68,0.15); border-color: rgba(239,68,68,0.45); color: var(--danger); }
+/* Reconfirm (stale deck) and warn (cross-check) share an amber tone, distinct
+   from the red pool-vs-cube conflict badge. */
+.ocr-badge.reconfirm { background: rgba(234,179,8,0.15); border-color: rgba(234,179,8,0.45); color: #eab308; cursor: help; }
+.ocr-badge.warn { background: rgba(234,179,8,0.12); border-color: rgba(234,179,8,0.4); color: #eab308; cursor: help; }
+/* Progress dot on the player list: green=done, yellow=in progress, red=unstarted. */
+.ocr-status-dot { flex: none; width: 10px; height: 10px; border-radius: 50%; }
+.ocr-status-dot.done { background: #22c55e; }
+.ocr-status-dot.in_progress { background: #eab308; }
+.ocr-status-dot.unstarted { background: #ef4444; }
+
+/* ── OCR import workspace ─────────────────────────────────────────── */
+.ocr-workspace { --ocr-radius: 10px; }
+.ocr-cols { display: flex; gap: 20px; align-items: flex-start; }
+.ocr-left { flex: 1 1 auto; min-width: 0; }
+.ocr-right { flex: 0 1 760px; min-width: 0; }
+
+.ocr-viewer { display: flex; flex-direction: column; height: calc(100vh - 160px); min-height: 420px; }
+.ocr-zoom { flex: none; display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+.ocr-zoom button {
+  min-width: 30px; height: 28px; padding: 0 9px; border-radius: 7px;
+  background: var(--card-background); border: 1px solid var(--border); color: var(--white);
+  cursor: pointer; font-size: 1em; line-height: 1; transition: border-color 0.15s ease, background 0.15s ease;
+}
+.ocr-zoom button:hover:not(:disabled) { border-color: var(--primary); }
+.ocr-zoom button:disabled { opacity: 0.4; cursor: default; }
+.ocr-zoom .ocr-zoom-fit { font-size: 0.85em; }
+.ocr-zoom .ocr-rotate { font-size: 1.1em; }
+.ocr-zoom span { min-width: 44px; text-align: center; color: var(--text-muted); font-size: 0.85em; font-variant-numeric: tabular-nums; }
+.ocr-zoom .ocr-redetect { margin-left: auto; font-size: 0.85em; white-space: nowrap; }
+.ocr-zoom .ocr-clear { font-size: 0.85em; white-space: nowrap; }
+
+.ocr-canvas-scroll {
+  flex: 1 1 auto; overflow: auto; min-height: 0;
+  display: flex; align-items: safe center; justify-content: safe center;
+  border-radius: var(--ocr-radius);
+  border: 1px solid var(--border); box-shadow: 0 8px 24px rgba(0,0,0,0.35); background: #0b1220;
+}
+.ocr-canvas { position: relative; flex: none; }
+.ocr-canvas img { width: 100%; display: block; }
+.ocr-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: crosshair; }
+.ocr-overlay rect, .ocr-overlay text { transition: stroke-width 0.12s ease, fill 0.12s ease; }
+
+.ocr-thumbs { flex: none; display: flex; gap: 8px; margin-top: 12px; flex-wrap: wrap; }
+.ocr-thumbs button {
+  padding: 0; border: 2px solid transparent; border-radius: 6px; background: none;
+  cursor: pointer; overflow: hidden; line-height: 0; transition: border-color 0.15s ease, transform 0.15s ease;
+}
+.ocr-thumbs button:hover { transform: translateY(-2px); }
+.ocr-thumbs button.active { border-color: var(--primary); box-shadow: 0 0 0 1px var(--primary); }
+.ocr-thumbs img { width: 84px; display: block; }
+
+.ocr-progress {
+  font-size: 0.85em; color: var(--text-muted); margin-bottom: 12px;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.ocr-progress::before {
+  content: ""; width: 10px; height: 10px; border-radius: 50%;
+  border: 2px solid var(--primary); border-top-color: transparent;
+  animation: ocr-spin 0.7s linear infinite;
+}
+@keyframes ocr-spin { to { transform: rotate(360deg); } }
+
+/* card-style right panel */
+.ocr-pool, .ocr-sideboard {
+  background: var(--card-background); border: 1px solid var(--border);
+  border-radius: var(--ocr-radius); padding: 14px 16px; margin-bottom: 16px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+}
+.ocr-pool-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
+.ocr-pool-head h3 { margin: 0; font-size: 1.05em; letter-spacing: 0.01em; }
+.ocr-pool-head .ok { color: #22c55e; font-variant-numeric: tabular-nums; font-weight: 600; }
+.ocr-pool-head .warn { color: #eab308; font-variant-numeric: tabular-nums; font-weight: 600; }
+.ocr-breakdown { color: var(--text-muted); font-size: 0.85em; font-variant-numeric: tabular-nums; }
+
+.ocr-pool-list { list-style: none; padding: 0; margin: 0; }
+.ocr-pool-list li {
+  display: flex; gap: 8px; align-items: center; padding: 4px 6px;
+  border-radius: 6px; transition: background 0.12s ease;
+}
+.ocr-pool-list li + li { border-top: 1px solid rgba(148,163,184,0.08); }
+.ocr-rownum {
+  flex: none; width: 22px; text-align: right; font-variant-numeric: tabular-nums;
+  color: var(--text-muted); font-size: 12px;
+}
+.ocr-pool-list li.hot { background: var(--highlight); box-shadow: inset 2px 0 0 var(--primary); }
+.ocr-pool-list li.over { background: rgba(239,68,68,0.15); }
+.ocr-pool-list select {
+  flex: 1 1 auto; min-width: 0; background: var(--page-background); color: inherit;
+  border: 1px solid var(--border); border-radius: 6px; padding: 3px 6px;
+}
+.ocr-count { display: inline-flex; align-items: center; gap: 4px; font-variant-numeric: tabular-nums; }
+.ocr-count button {
+  width: 22px; height: 22px; border-radius: 5px; border: 1px solid var(--border);
+  background: var(--page-background); color: inherit; cursor: pointer; line-height: 1;
+}
+.ocr-count button:hover { border-color: var(--primary); color: var(--primary); }
+.ocr-move {
+  background: none; border: 1px solid var(--border); border-radius: 5px; color: var(--text-muted);
+  cursor: pointer; padding: 2px 7px; font-size: 0.8em; white-space: nowrap;
+}
+.ocr-move:hover { border-color: var(--primary); color: var(--primary); }
+.ocr-rm {
+  margin-left: auto; background: none; border: none; color: var(--text-muted);
+  cursor: pointer; font-size: 1.1em; line-height: 1; padding: 0 4px;
+}
+.ocr-rm:hover { color: var(--danger); }
+
+.ocr-snip {
+  position: relative; flex: 0 0 auto; overflow: hidden; border-radius: 4px;
+  background: var(--page-background); border: 1px solid var(--border);
+}
+.ocr-snip-empty { border-style: dashed; opacity: 0.4; }
+.ocr-conf {
+  display: inline-flex; align-items: center; gap: 4px; flex: 0 0 auto;
+  font-size: 0.8em; color: var(--text-muted); font-variant-numeric: tabular-nums;
+}
+.ocr-conf-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.ocr-conf-manual { color: var(--text-muted); }
+
+.ocr-pool-list li.ocr-unmatched {
+  background: rgba(239,68,68,0.10); box-shadow: inset 2px 0 0 var(--danger);
+  align-items: flex-start;
+}
+.ocr-unmatched .ocr-conf-dot { margin-top: 8px; }
+.ocr-unmatched-pick { flex: 1 1 auto; min-width: 0; }
+.ocr-unmatched-pick .ocr-add { margin-top: 0; }
+.ocr-cand { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+.ocr-cand button {
+  background: none; border: 1px solid var(--border); border-radius: 5px; color: var(--text-muted);
+  cursor: pointer; padding: 1px 6px; font-size: 0.78em; font-variant-numeric: tabular-nums;
+}
+.ocr-cand button:hover { border-color: var(--primary); color: var(--primary); }
+
+.ocr-sort {
+  display: flex; gap: 4px; margin-bottom: 6px;
+}
+.ocr-sort button {
+  background: none; border: 1px solid var(--border); border-radius: 5px; color: var(--text-muted);
+  cursor: pointer; padding: 2px 9px; font-size: 0.8em;
+}
+.ocr-sort button:hover { border-color: var(--primary); color: var(--primary); }
+.ocr-sort button.active { background: var(--primary); border-color: var(--primary); color: var(--white); }
+
+.ocr-add { position: relative; margin-top: 10px; }
+.ocr-add input {
+  width: 100%; box-sizing: border-box; background: var(--page-background); color: inherit;
+  border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px;
+}
+.ocr-add input:focus { outline: none; border-color: var(--primary); }
+.ocr-ac {
+  position: absolute; z-index: 5; background: var(--page-background); border: 1px solid var(--border);
+  border-radius: 6px; list-style: none; margin: 2px 0 0; padding: 4px; width: 100%;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.4);
+}
+.ocr-ac button { width: 100%; text-align: left; background: none; border: none; color: inherit; padding: 5px 8px; border-radius: 4px; cursor: pointer; }
+.ocr-ac button:hover, .ocr-ac button.active { background: var(--table-row-hover); }
+
+.ocr-basics { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border); }
+.ocr-basics h4 { margin: 0 0 8px; font-size: 0.9em; color: var(--text-muted); }
+.ocr-basics label { display: inline-flex; gap: 4px; align-items: center; margin: 0 12px 6px 0; font-size: 0.9em; }
+.ocr-basics button {
+  width: 20px; height: 20px; border-radius: 5px; border: 1px solid var(--border);
+  background: var(--page-background); color: inherit; cursor: pointer; line-height: 1;
+}
+.ocr-basics button:hover { border-color: var(--primary); color: var(--primary); }
+
+.ocr-sideboard h4 { margin: 0 0 8px; font-size: 0.95em; }
+.ocr-sideboard ul { list-style: none; padding: 0; margin: 0; }
+.ocr-sideboard li {
+  display: flex; align-items: center; gap: 8px; padding: 4px 6px; border-radius: 6px;
+  transition: background 0.12s ease;
+}
+.ocr-sideboard li.hot { background: var(--highlight); box-shadow: inset 2px 0 0 var(--primary); }
+.ocr-sideboard li span { flex: 1 1 auto; }
+
+.ocr-tabs { display: flex; gap: 6px; margin-bottom: 16px; }
+.ocr-tabs button {
+  padding: 6px 16px; border-radius: 8px; background: var(--card-background);
+  border: 1px solid var(--border); color: var(--text-muted); cursor: pointer;
+  text-transform: capitalize; transition: all 0.15s ease;
+}
+.ocr-tabs button:hover { color: var(--white); }
+.ocr-tabs button.active { border-color: var(--primary); color: var(--primary); background: rgba(56,189,248,0.08); }
+
+.ocr-warnings {
+  background: rgba(234,179,8,0.1); border: 1px solid rgba(234,179,8,0.3); border-left: 3px solid #eab308;
+  border-radius: 8px; padding: 8px 14px; list-style: none; margin: 0 0 16px;
+}
+.ocr-warnings li { padding: 2px 0; font-size: 0.9em; }
+
+.ocr-confirm {
+  background: var(--card-background); border: 1px solid var(--border);
+  border-radius: var(--ocr-radius); padding: 20px;
+}
+.ocr-confirm-btn {
+  background: var(--primary); color: #0f172a; border: none; border-radius: 8px;
+  padding: 10px 20px; cursor: pointer; font-weight: 600; transition: background 0.15s ease;
+}
+.ocr-confirm-btn:hover { background: var(--primary-hover); }
+.ocr-slideshow {
+  display: flex; flex-direction: column; align-items: center; gap: 14px; padding: 20px 0;
+}
+.ocr-slide-progress { color: var(--text-muted); font-size: 0.85em; font-variant-numeric: tabular-nums; }
+.ocr-slideshow .ocr-snip { border-width: 2px; max-width: 100%; }
+.ocr-slide-name { font-size: 1.5em; font-weight: 700; text-align: center; }
+.ocr-slide-actions { display: flex; gap: 28px; }
+.ocr-slide-actions button {
+  width: 64px; height: 64px; border-radius: 50%; border: 2px solid var(--border);
+  background: var(--card-background); font-size: 1.7em; line-height: 1; cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.ocr-slide-yes { color: #22c55e; }
+.ocr-slide-yes:hover { background: #22c55e; color: #0f172a; border-color: #22c55e; }
+.ocr-slide-no { color: #ef4444; }
+.ocr-slide-no:hover { background: #ef4444; color: #fff; border-color: #ef4444; }
+.ocr-slide-hint { color: var(--text-muted); font-size: 0.8em; }
+.ocr-slide-fix { width: 100%; max-width: 420px; display: flex; flex-direction: column; align-items: center; gap: 8px; }
+.ocr-slide-fix .ocr-add { width: 100%; }
+.ocr-slideshow-done { color: var(--text-muted); }
+.ocr-slideshow-done button {
+  background: var(--card-background); border: 1px solid var(--border); color: var(--white);
+  border-radius: 7px; padding: 7px 14px; cursor: pointer;
+}


### PR DESCRIPTION
Adds the top-level OCRImport page (draft -> player -> reconcile workspace) and wires it into the router and navbar. This makes the OCR feature reachable in the UI for the first time. Also appends the OCR import CSS.