### PR TITLE
index: skip dotfiles so the OCR session file isn't indexed as a deck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/oracle-cards.json
 package-lock.json
 *.created
 venv/
+.ocr-session.json

--- a/data/polyverse/index.json
+++ b/data/polyverse/index.json
@@ -768,9 +768,6 @@
    "draft_log": "",
    "decks": [
     {
-     "path": "data/polyverse/2025-10-04_ccc2025_2/.ocr-session.json"
-    },
-    {
      "path": "data/polyverse/2025-10-04_ccc2025_2/2025-10-04_ccc2025_2-p1.json"
     },
     {
@@ -802,9 +799,6 @@
    "draft_id": "2025-10-04_ccc2025_3",
    "draft_log": "",
    "decks": [
-    {
-     "path": "data/polyverse/2025-10-04_ccc2025_3/.ocr-session.json"
-    },
     {
      "path": "data/polyverse/2025-10-04_ccc2025_3/2025-10-04_ccc2025_3-p1.json"
     },
@@ -988,9 +982,6 @@
    "draft_id": "2026-06-20_bcp26_1",
    "draft_log": "",
    "decks": [
-    {
-     "path": "data/polyverse/2026-06-20_bcp26_1/.ocr-session.json"
-    },
     {
      "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p1.json"
     },

--- a/pkg/commands/index.go
+++ b/pkg/commands/index.go
@@ -151,6 +151,12 @@ func decksInDraft(directory string) []IndexedDeck {
 		// Get only the base name of the file
 		fileName := filepath.Base(file)
 
+		// Skip dotfiles. Go's glob (unlike a shell) matches leading dots, so
+		// *.json picks up the OCR import's .ocr-session.json working state.
+		if strings.HasPrefix(fileName, ".") {
+			continue
+		}
+
 		// Skip non-deck files in the draft directory.
 		switch fileName {
 		case "index.json", "metadata.json", "cube.json", "cube-rules.json",


### PR DESCRIPTION
Go's glob matches leading dots (a shell's doesn't), so `*.json` was picking up the OCR import's `.ocr-session.json` working state and indexing it as a deck - which then warned "Failed to load deck" once the session file was removed. Skip dotfiles in the indexer, drop the 3 stale entries already baked into polyverse/index.json, and gitignore the session file.