### PR TITLE
data: drop duplicate round-4 matches (re-entries of the round-2 matches)

### DIFF
--- a/data/polyverse/2024-03-28_local_1/casey.json
+++ b/data/polyverse/2024-03-28_local_1/casey.json
@@ -31,24 +31,6 @@
    "winner": "ken"
   },
   {
-   "opponent": "matthew",
-   "round": 4,
-   "wins": 0,
-   "losses": 2,
-   "draws": 0,
-   "games": [
-    {
-     "opponent": "matthew",
-     "winner": "matthew"
-    },
-    {
-     "opponent": "matthew",
-     "winner": "matthew"
-    }
-   ],
-   "winner": "matthew"
-  },
-  {
    "opponent": "matthewbk",
    "round": 2,
    "wins": 0,

--- a/data/polyverse/2025-08-17_local_1/kevin.json
+++ b/data/polyverse/2025-08-17_local_1/kevin.json
@@ -34,24 +34,6 @@
    "winner": "kevin"
   },
   {
-   "opponent": "brian",
-   "round": 4,
-   "wins": 2,
-   "losses": 0,
-   "draws": 0,
-   "games": [
-    {
-     "opponent": "brian",
-     "winner": "kevin"
-    },
-    {
-     "opponent": "brian",
-     "winner": "kevin"
-    }
-   ],
-   "winner": "kevin"
-  },
-  {
    "opponent": "brianfl",
    "round": 2,
    "wins": 2,


### PR DESCRIPTION
kevin.json and casey.json each had a round-4 match against a short-named opponent (`brian`, `matthew`) with the same result as their round-2 match against `brianfl`/`matthewbk`. The real round-4 opponents are recorded bilaterally as michael and jan, so these were duplicate entries of the round-2 matches, not real replays. Drop them - this also clears the "failed to find opponent deck" warnings and un-double-counts the records.