### PR TITLE
Local dev hot-reload and tag autocomplete fix

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,17 @@
+# air config for the in-container dev loop (see Dockerfile.server-ocr-dev). Builds
+# the OCR server with CGO + the ocr_cv tag and restarts it on any .go change.
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "CGO_ENABLED=1 go build -tags ocr_cv -o ./tmp/server-ocr ./cmd/server/server.go"
+  bin = "./tmp/server-ocr"
+  include_ext = ["go"]
+  # ui has its own watcher; the rest hold data or build output, not server source.
+  exclude_dir = ["ui", "data", "tmp", "bin", "node_modules"]
+  # Coalesce bursts of saves into one rebuild.
+  delay = 1000
+  stop_on_error = true
+
+[log]
+  time = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+tmp/
 input/
 node_modules/
 data/oracle-cards.json

--- a/Dockerfile.server-ocr-dev
+++ b/Dockerfile.server-ocr-dev
@@ -1,0 +1,28 @@
+# Dev image for the hot-reloading server loop (make dev). Carries the full build
+# toolchain - Go, g++, OpenCV dev headers, pkg-config - so `air` can recompile
+# the -tags ocr_cv binary inside the container on every save, plus the tesseract
+# CLI the OCR engine shells out to at runtime. Unlike Dockerfile.server-ocr this
+# does NOT copy the source: it's bind-mounted at /code so host edits trigger
+# rebuilds. go.mod/go.sum are copied only to warm the module cache (and pull the
+# pinned Go toolchain) into the image so the first in-container build is quick.
+FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	golang-go \
+	g++ \
+	libopencv-dev \
+	pkg-config \
+	tesseract-ocr \
+	ca-certificates \
+	git \
+	&& rm -rf /var/lib/apt/lists/*
+
+# air: Go live-reload (watches sources, rebuilds, restarts the binary).
+RUN go install github.com/air-verse/air@v1.52.3
+ENV PATH="/root/go/bin:${PATH}"
+
+# Warm the module cache and the pinned Go toolchain into an image layer.
+WORKDIR /code
+COPY go.mod go.sum ./
+RUN go mod download
+
+CMD ["air", "-c", ".air.toml"]

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,35 @@ reparse:
 data/oracle-cards.json:
 	./scripts/download-oracle-data $@
 
-# Full local dev stack: OCR-enabled backend on :8888 and the UI dev server on
-# :6060 (proxies /api to :8888). Ctrl-C stops both. Needs OpenCV + tesseract
-# installed locally; without tesseract the UI runs but scan/detect won't.
-run: data/oracle-cards.json bin/server-ocr
-	@command -v tesseract >/dev/null || echo "warning: tesseract not on PATH - OCR scan/detect will fail"
-	@cd ui && [ -d node_modules ] || npm install
-	./bin/server-ocr & \
-	server_pid=$$!; \
-	trap 'kill $$server_pid 2>/dev/null' EXIT INT TERM; \
+# Full local dev stack: the OCR backend on :8888 and the UI dev server on :6060
+# (proxies /api to :8888). Ctrl-C stops both. Runs the backend from the OCR
+# Docker image so OpenCV + tesseract come from the container, not the host - no
+# local install needed. The repo is mounted at /code so the container sees ./data.
+run: data/oracle-cards.json .server-ocr.created
+	@[ -d ui/node_modules ] || ( cd ui && npm install )
+	-docker rm -f cube-tools-server-ocr 2>/dev/null
+	docker run --rm --name=cube-tools-server-ocr --detach -p 8888:8888 \
+		-v $(PWD):/code \
+		caseydavenport/cube-tools-server-ocr
+	trap 'docker rm -f cube-tools-server-ocr 2>/dev/null' EXIT INT TERM; \
+	cd ui && npm start
+
+# Hot-reloading dev loop: the OCR server under `air` (rebuilds + restarts on
+# every .go save) plus the UI dev server, the same auto-update you get for the
+# UI. air runs inside a container carrying the Go toolchain + OpenCV headers +
+# tesseract, so rebuilds happen in-container and need nothing on the host. The
+# repo is bind-mounted at /code, so host edits trigger rebuilds; the named
+# gocache volume keeps the Go build cache warm across runs so rebuilds stay fast.
+# Ctrl-C stops both.
+dev: data/oracle-cards.json .server-ocr-dev.created
+	@[ -d ui/node_modules ] || ( cd ui && npm install )
+	-docker rm -f cube-tools-server-dev 2>/dev/null
+	docker run --rm --name=cube-tools-server-dev --detach -p 8888:8888 \
+		-v $(PWD):/code \
+		-v cube-tools-gocache:/root/.cache/go-build \
+		caseydavenport/cube-tools-server-dev
+	@echo "server running under air in container - edit a .go file to rebuild; tail with: docker logs -f cube-tools-server-dev"
+	trap 'docker rm -f cube-tools-server-dev 2>/dev/null' EXIT INT TERM; \
 	cd ui && npm start
 
 ###################
@@ -70,6 +90,13 @@ run-server-ocr: .server-ocr.created
 	docker run --rm --name=cube-tools-server-ocr --detach -p 8888:8888 \
 		-v $(PWD):/code \
 		caseydavenport/cube-tools-server-ocr
+
+# Dev image for `make dev`: build toolchain + OpenCV + tesseract + air. Depends
+# only on the Dockerfile (source is bind-mounted at run time, not copied in), so
+# it rebuilds when the dev image definition changes, not on every code edit.
+.server-ocr-dev.created: Dockerfile.server-ocr-dev go.mod go.sum
+	docker build -t caseydavenport/cube-tools-server-dev -f Dockerfile.server-ocr-dev .
+	touch $@
 
 ###################
 # Parse CLI build

--- a/ui/src/components/TagEditor.js
+++ b/ui/src/components/TagEditor.js
@@ -1,23 +1,39 @@
-import React, { useState, useId } from 'react'
+import React, { useState, useRef } from 'react'
 
-// TagEditor renders the current tags as removable pills plus a text input with
-// datalist autocomplete. onChange fires with the complete new tag list whenever
-// a tag is added (Enter) or removed (pill x). Duplicates and blanks are ignored.
+// TagEditor renders the current tags as removable pills plus a text input with a
+// custom autocomplete dropdown. onChange fires with the complete new tag list
+// whenever a tag is added (Enter, click a suggestion) or removed (pill x, or
+// Backspace on an empty input). Duplicates and blanks are ignored.
+//
+// This used to lean on a native <datalist>, but its popup was unreliable about
+// when it surfaced suggestions, so we render our own dropdown (same styling as
+// the search autocomplete) for predictable behavior across browsers.
 export function TagEditor({ tags, suggestions, onChange }) {
   const [text, setText] = useState("")
+  const [open, setOpen] = useState(false)
+  // -1 means "no suggestion highlighted - Enter adds the typed text"; >=0 picks
+  // the highlighted suggestion. Lets you both add existing tags and brand-new ones.
+  const [selected, setSelected] = useState(-1)
   const current = tags || []
-  // Unique per instance so multiple TagEditors on one page (e.g. the selected
-  // deck plus comparison decks) don't share a datalist and cross-wire suggestions.
-  const listId = useId()
+  const blurTimeout = useRef(null)
+
+  // Suggestions not already added, matched as a case-insensitive substring of
+  // what's typed. Empty input shows the full remaining list (so focus reveals it).
+  const q = text.trim().toLowerCase()
+  const matches = (suggestions || [])
+    .filter((s) => !current.includes(s))
+    .filter((s) => q === "" || s.toLowerCase().includes(q))
 
   const addTag = (raw) => {
     const t = raw.trim()
     if (!t || current.includes(t)) {
       setText("")
+      setSelected(-1)
       return
     }
     onChange([...current, t])
     setText("")
+    setSelected(-1)
   }
 
   const removeTag = (t) => {
@@ -25,20 +41,38 @@ export function TagEditor({ tags, suggestions, onChange }) {
   }
 
   const onKeyDown = (e) => {
-    if (e.key === "Enter") {
+    if (e.key === "ArrowDown") {
       e.preventDefault()
-      addTag(text)
-    } else if (e.key === "Tab" && text.trim() !== "") {
-      // Complete the current tag but keep focus here so the user can keep adding.
+      setOpen(true)
+      setSelected((i) => Math.min(i + 1, matches.length - 1))
+    } else if (e.key === "ArrowUp") {
       e.preventDefault()
-      addTag(text)
+      setSelected((i) => Math.max(i - 1, -1))
+    } else if (e.key === "Enter" || (e.key === "Tab" && text.trim() !== "")) {
+      // Enter/Tab commits: the highlighted suggestion if there is one, else the
+      // typed text. Tab keeps focus so you can keep adding tags.
+      e.preventDefault()
+      addTag(selected >= 0 && matches[selected] ? matches[selected] : text)
+    } else if (e.key === "Escape") {
+      setOpen(false)
+      setSelected(-1)
     } else if (e.key === "Backspace" && text === "" && current.length > 0) {
       removeTag(current[current.length - 1])
     }
   }
 
+  const onFocus = () => {
+    if (blurTimeout.current) clearTimeout(blurTimeout.current)
+    setOpen(true)
+  }
+
+  // Delay close so a mousedown on a suggestion still registers before blur hides it.
+  const onBlur = () => {
+    blurTimeout.current = setTimeout(() => setOpen(false), 150)
+  }
+
   return (
-    <div className="tag-editor" style={{"display": "flex", "flexWrap": "wrap", "alignItems": "center", "gap": "0.25rem"}}>
+    <div className="tag-editor" style={{"position": "relative", "display": "flex", "flexWrap": "wrap", "alignItems": "center", "gap": "0.25rem"}}>
       {current.map((t) => (
         <span key={t} className="tag-pill" style={{"display": "inline-flex", "alignItems": "center", "gap": "0.25rem", "padding": "0.1rem 0.4rem", "borderRadius": "0.75rem", "background": "var(--border)"}}>
           {t}
@@ -47,17 +81,28 @@ export function TagEditor({ tags, suggestions, onChange }) {
       ))}
       <input
         className="text-input"
-        list={listId}
         value={text}
         placeholder="Add tag…"
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e) => { setText(e.target.value); setOpen(true); setSelected(-1) }}
         onKeyDown={onKeyDown}
-        onBlur={() => addTag(text)}
+        onFocus={onFocus}
+        onBlur={onBlur}
         style={{"minWidth": "6rem", "flex": "1"}}
       />
-      <datalist id={listId}>
-        {(suggestions || []).map((s) => <option key={s} value={s} />)}
-      </datalist>
+      {open && matches.length > 0 && (
+        <div className="search-autocomplete" style={{"width": "100%"}}>
+          {matches.map((s, idx) => (
+            <div
+              key={s}
+              className={"search-autocomplete-item" + (idx === selected ? " search-autocomplete-item-selected" : "")}
+              onMouseDown={(e) => { e.preventDefault(); addTag(s) }}
+              onMouseEnter={() => setSelected(idx)}
+            >
+              <span className="search-autocomplete-term">{s}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Two local-dev improvements that came out of getting the stack running.

make run was failing because it built the OCR backend natively, which needs OpenCV and tesseract on the host. It now runs the backend from the OCR Docker image instead, so no host install is needed. Added make dev alongside it: same containerized backend but under air, so the server rebuilds and restarts on save (the UI already hot-reloads).

Also fixed tag autocomplete in the deck editor. The tag field used a native datalist, which was unreliable about surfacing suggestions. Replaced it with a custom dropdown that filters existing tags as you type.
