### PR TITLE
Classify polyverse bcp26 decks

### DIFF
--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p1.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p1.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p1.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
- "labels": [],
+ "macro_archetype": "aggro",
+ "labels": [
+  "sacrifice",
+  "recursion"
+ ],
  "player": "2026-06-20_bcp26_1-p1",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p2.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p2.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p2.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
+ "macro_archetype": "aggro",
  "labels": [],
  "player": "2026-06-20_bcp26_1-p2",
  "date": "2026-06-20",
@@ -85,5 +86,9 @@
   "Mystic Sanctuary",
   "Read the Bones",
   "Unexpectedly Absent"
+ ],
+ "colors": [
+  "W",
+  "B"
  ]
 }

--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p3.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p3.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p3.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
+ "macro_archetype": "midrange",
  "labels": [],
  "player": "2026-06-20_bcp26_1-p3",
  "date": "2026-06-20",

--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p4.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p4.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p4.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
- "labels": [],
+ "macro_archetype": "control",
+ "labels": [
+  "saga",
+  "token"
+ ],
  "player": "2026-06-20_bcp26_1-p4",
  "date": "2026-06-20",
  "matches": [
@@ -86,5 +90,9 @@
   "Spell Pierce",
   "Spell Snare",
   "Touch the Spirit Realm"
+ ],
+ "colors": [
+  "U",
+  "G"
  ]
 }

--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p5.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p5.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p5.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "draw",
+  "graveyard"
+ ],
  "player": "2026-06-20_bcp26_1-p5",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p6.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p6.json
@@ -3,7 +3,10 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p6.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "domain"
+ ],
  "player": "2026-06-20_bcp26_1-p6",
  "date": "2026-06-20",
  "matches": [
@@ -83,5 +86,12 @@
   "Magma Jet",
   "Mutavault",
   "Werefox Bodyguard"
+ ],
+ "colors": [
+  "W",
+  "U",
+  "B",
+  "R",
+  "G"
  ]
 }

--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p7.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p7.json
@@ -3,7 +3,10 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p7.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "delney"
+ ],
  "player": "2026-06-20_bcp26_1-p7",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p8.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p8.json
@@ -3,7 +3,12 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p8.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
- "labels": [],
+ "macro_archetype": "tempo",
+ "labels": [
+  "valiant",
+  "heartfire",
+  "prowess"
+ ],
  "player": "2026-06-20_bcp26_1-p8",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p1.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p1.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p1.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "labels": [],
+ "macro_archetype": "tempo",
+ "labels": [
+  "draw",
+  "skimmer"
+ ],
  "player": "2026-06-20_bcp26_2-p1",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p2.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p2.json
@@ -3,7 +3,10 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p2.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "labels": [],
+ "macro_archetype": "tempo",
+ "labels": [
+  "delney"
+ ],
  "player": "2026-06-20_bcp26_2-p2",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p3.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p3.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p3.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
+ "macro_archetype": "control",
  "labels": [],
  "player": "2026-06-20_bcp26_2-p3",
  "date": "2026-06-20",

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p4.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p4.json
@@ -3,7 +3,10 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p4.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "token"
+ ],
  "player": "2026-06-20_bcp26_2-p4",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p5.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p5.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p5.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
+ "macro_archetype": "aggro",
  "labels": [],
  "player": "2026-06-20_bcp26_2-p5",
  "date": "2026-06-20",

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p6.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p6.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p6.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "ramp",
+  "lands"
+ ],
  "player": "2026-06-20_bcp26_2-p6",
  "date": "2026-06-20",
  "matches": [
@@ -92,5 +96,8 @@
   "Seal of Removal",
   "Sheltered Thicket",
   "Stomping Ground"
+ ],
+ "colors": [
+  "G"
  ]
 }

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p7.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p7.json
@@ -3,7 +3,10 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p7.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "domain"
+ ],
  "player": "2026-06-20_bcp26_2-p7",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p8.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p8.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p8.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "labels": [],
+ "macro_archetype": "tempo",
+ "labels": [
+  "sacrifice",
+  "spells"
+ ],
  "player": "2026-06-20_bcp26_2-p8",
  "date": "2026-06-20",
  "matches": [

--- a/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p3.json
+++ b/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p3.json
@@ -3,7 +3,12 @@
   "path": "data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p3.json",
   "draft_id": "2026-06-20_bcp26_3"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "ritual",
+  "roots",
+  "recursion"
+ ],
  "player": "2026-06-20_bcp26_3-p3",
  "date": "2026-06-20",
  "matches": [
@@ -80,5 +85,9 @@
   "Underground Mortuary",
   "Unearth",
   "Virtue of Persistence // Locthwain Scorn"
+ ],
+ "colors": [
+  "B",
+  "G"
  ]
 }

--- a/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p5.json
+++ b/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p5.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p5.json",
   "draft_id": "2026-06-20_bcp26_3"
  },
+ "macro_archetype": "aggro",
  "labels": [],
  "player": "2026-06-20_bcp26_3-p5",
  "date": "2026-06-20",
@@ -80,5 +81,9 @@
   "Welcoming Vampire",
   "Windswept Heath",
   "Wooded Foothills"
+ ],
+ "colors": [
+  "W",
+  "R"
  ]
 }

--- a/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p6.json
+++ b/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p6.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p6.json",
   "draft_id": "2026-06-20_bcp26_3"
  },
- "labels": [],
+ "macro_archetype": "aggro",
+ "labels": [
+  "prowess",
+  "sacrifice"
+ ],
  "player": "2026-06-20_bcp26_3-p6",
  "date": "2026-06-20",
  "matches": [
@@ -90,7 +94,6 @@
   "Steam Vents"
  ],
  "colors": [
-  "R",
-  "G"
+  "R"
  ]
 }

--- a/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p7.json
+++ b/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p7.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p7.json",
   "draft_id": "2026-06-20_bcp26_3"
  },
+ "macro_archetype": "control",
  "labels": [],
  "player": "2026-06-20_bcp26_3-p7",
  "date": "2026-06-20",

--- a/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p8.json
+++ b/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p8.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p8.json",
   "draft_id": "2026-06-20_bcp26_3"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "token",
+  "ramp"
+ ],
  "player": "2026-06-20_bcp26_3-p8",
  "date": "2026-06-20",
  "matches": [
@@ -87,5 +91,9 @@
   "Thoughtseize",
   "Toxic Deluge",
   "Utopia Sprawl"
+ ],
+ "colors": [
+  "W",
+  "G"
  ]
 }

--- a/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p2.json
+++ b/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p2.json
@@ -3,7 +3,11 @@
   "path": "data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p2.json",
   "draft_id": "2026-06-21_bcp26_1"
  },
- "labels": [],
+ "macro_archetype": "midrange",
+ "labels": [
+  "spells",
+  "sacrifice"
+ ],
  "player": "2026-06-21_bcp26_1-p2",
  "date": "2026-06-21",
  "matches": [
@@ -80,5 +84,10 @@
   "Werefox Bodyguard",
   "Wooded Foothills",
   "Young Pyromancer"
+ ],
+ "colors": [
+  "W",
+  "U",
+  "R"
  ]
 }

--- a/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p3.json
+++ b/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p3.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p3.json",
   "draft_id": "2026-06-21_bcp26_1"
  },
+ "macro_archetype": "midrange",
  "labels": [],
  "player": "2026-06-21_bcp26_1-p3",
  "date": "2026-06-21",
@@ -80,5 +81,9 @@
   "Warden of the Inner Sky",
   "Welcoming Vampire",
   "Wither and Bloom"
+ ],
+ "colors": [
+  "W",
+  "B"
  ]
 }

--- a/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p5.json
+++ b/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p5.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p5.json",
   "draft_id": "2026-06-21_bcp26_1"
  },
+ "macro_archetype": "midrange",
  "labels": [],
  "player": "2026-06-21_bcp26_1-p5",
  "date": "2026-06-21",
@@ -80,5 +81,10 @@
   "Verdant Catacombs",
   "Windswept Heath",
   "Woodland Wanderer"
+ ],
+ "colors": [
+  "W",
+  "U",
+  "G"
  ]
 }

--- a/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p7.json
+++ b/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p7.json
@@ -3,6 +3,7 @@
   "path": "data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p7.json",
   "draft_id": "2026-06-21_bcp26_1"
  },
+ "macro_archetype": "control",
  "labels": [],
  "player": "2026-06-21_bcp26_1-p7",
  "date": "2026-06-21",
@@ -80,5 +81,9 @@
   "Ulcerate",
   "Watery Grave",
   "Wrath of God"
+ ],
+ "colors": [
+  "U",
+  "B"
  ]
 }


### PR DESCRIPTION
Adds macro archetype, tags, and color identity to the bcp26 decks. Data only, no code changes.
