### PR TITLE
Align Analyze pages on a shared shell, starting with Archetypes

### DIFF
--- a/pkg/server/stats/cards.go
+++ b/pkg/server/stats/cards.go
@@ -232,9 +232,14 @@ func (d *cardStatsHandler) statsForDecks(decks []*storage.Deck, cubeCards map[st
 			// Increment player count.
 			cbn.Players[deck.Player]++
 
-			// Include archetype data for this card
+			// Include archetype data for this card. The macro archetype is counted
+			// alongside the secondary labels so selecting a macro (aggro/midrange/
+			// control/tempo) matches the cards played in it.
 			for _, l := range deck.Labels {
 				cbn.Archetypes[l]++
+			}
+			if arch != "" {
+				cbn.Archetypes[arch]++
 			}
 
 			// Track drafts for this card.

--- a/ui/src/components/PageSections.js
+++ b/ui/src/components/PageSections.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+import React from 'react';
+
+// Section wraps a content block on an Analyze page with a consistent heading
+// and an id that the in-page SectionNav can jump to.
+export function Section({ id, heading, children }) {
+  return (
+    <section id={id} className="page-section">
+      {heading && <h3 className="section-heading">{heading}</h3>}
+      {children}
+    </section>
+  );
+}
+
+// SectionNav renders the sticky in-page jump strip. It scroll-spies the active
+// section via an IntersectionObserver and scrolls to a section on click.
+// sections is an array of { id, label }; pass a stable reference so the
+// observer isn't torn down every render.
+export function SectionNav({ sections }) {
+  const [active, setActive] = React.useState(sections[0] ? sections[0].id : null);
+
+  React.useEffect(() => {
+    const visible = new Set();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (let e of entries) {
+          if (e.isIntersecting) {
+            visible.add(e.target.id);
+          } else {
+            visible.delete(e.target.id);
+          }
+        }
+        // Highlight the topmost section currently in view (first in declared
+        // order), so it stays correct even when several are visible at once.
+        for (let s of sections) {
+          if (visible.has(s.id)) {
+            setActive(s.id);
+            break;
+          }
+        }
+      },
+      // Trip the active section once it clears the sticky chrome at the top.
+      { rootMargin: "-130px 0px -65% 0px" }
+    );
+    for (let s of sections) {
+      let el = document.getElementById(s.id);
+      if (el) observer.observe(el);
+    }
+    return () => observer.disconnect();
+  }, [sections]);
+
+  const jump = (e, id) => {
+    e.preventDefault();
+    let el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
+  return (
+    <nav className="section-nav">
+      {sections.map((s) => (
+        <a
+          key={s.id}
+          href={`#${s.id}`}
+          className={s.id === active ? "active" : ""}
+          onClick={(e) => jump(e, s.id)}
+        >
+          {s.label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/ui/src/components/StatsUI.js
+++ b/ui/src/components/StatsUI.js
@@ -3,8 +3,21 @@ import { Button, TextInput, NumericInput, DateSelector } from "../components/Dro
 import { PillSearchInput } from "../components/PillSearchInput.js";
 
 export function SelectorBar(input) {
+  // Publish the bar's height so the in-page section nav can stick directly
+  // below it (the bar is sticky and its height changes as filter pills wrap).
+  const ref = React.useRef(null);
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const update = () => document.documentElement.style.setProperty('--selectorbar-height', el.offsetHeight + 'px');
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   return (
-    <div className="selectorbar">
+    <div className="selectorbar" ref={ref}>
       <div className="selector-group">
         <Button text="Refresh" onClick={input.triggerRefresh} />
         <DateSelector label="From" id="from" value={input.startDate} onChange={input.onStartSelected} />

--- a/ui/src/components/navbar.js
+++ b/ui/src/components/navbar.js
@@ -49,7 +49,7 @@ const SECTIONS = [
   { label: "Analyze", views: [
     { label: "Cards", path: "cards" },
     { label: "Colors", path: "colors" },
-    { label: "Types", path: "types" },
+    { label: "Archetypes", path: "types" },
     { label: "Decks", path: "deckstats" },
   ]},
   { label: "Design", views: [

--- a/ui/src/pages/Stats.js
+++ b/ui/src/pages/Stats.js
@@ -136,7 +136,7 @@ export function StatsViewer(props) {
   }, [decks]);
 
   return (
-    <div id="root">
+    <div id="root" className="stats-root">
       <SelectorBar
         triggerRefresh={triggerRefresh}
         startDate={props.startDate}

--- a/ui/src/pages/Types.js
+++ b/ui/src/pages/Types.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { IsBasicLand, MinWinningPctDecks, Pct, SortFunc, StringToColor } from "../utils/Utils.js"
 import { Trophies, LastPlaceFinishes, Winning, Losing, Wins, Losses } from "../utils/Deck.js"
 import { DropdownHeader, NumericInput, Checkbox, DateSelector } from "../components/Dropdown.js"
+import { Section, SectionNav } from "../components/PageSections.js"
 import { BucketName, bucketXScale } from "../utils/Buckets.js"
 import { Red, Green, Black, White, Blue, Colors, ColorImages, CUBE_AVG_WIN_PERCENT, deltaPositiveFill, deltaNegativeFill } from "../utils/Colors.js"
 
@@ -45,6 +46,12 @@ const watermark = 100 * 1 / 32
 const winPctColor = "#fff"
 const winColor = Green
 const lossColor = Black // "#61892f"
+
+const ARCH_SECTIONS = [
+  { id: "archetypes", label: "Archetypes" },
+  { id: "selected-archetype", label: "Selected Archetype" },
+  { id: "trends", label: "Trends" },
+]
 
 export function ArchetypeWidget(input) {
   const [leftChart, setLeftChart] = React.useState("macro_builds")
@@ -104,68 +111,72 @@ export function ArchetypeWidget(input) {
   }
 
   return (
-    <div className="archetype-container">
-      <div className="archetype-top-section">
-        <div className="archetype-stats-wrapper">
-          <ArchetypeStatsTable
-            parsed={input.parsed}
-            decks={input.decks}
-            dropdownSelection={input.colorTypeSelection}
-            sortBy={input.sortBy}
-            onHeaderClick={input.onHeaderClick}
-            handleRowClick={input.handleRowClick}
-            selectedArchetype={input.selectedArchetype}
-            colorCheckboxes={input.colorCheckboxes}
-            onColorChecked={input.onColorChecked}
-          />
-        </div>
-        <div className="archetype-cards-wrapper">
-          <TopCardsInArchetypeWidget
-            parsed={input.parsed}
-            cardData={input.cardData}
-            decks={input.decks}
-            minDrafts={input.minDrafts}
-            cube={input.cube}
-            minDecksInArch={input.minDecksInArch}
-            archetypeDropdownOptions={input.archetypeDropdownOptions}
-            selectedArchetype={input.selectedArchetype}
-            onArchetypeSelected={input.onArchetypeSelected}
-            colorWidgetOpts={input.colorWidgetOpts}
-            onColorSelected={input.onColorSelected}
-            colorSelection={input.colorSelection}
-            onMinDraftsSelected={input.onMinDraftsSelected}
-            onMinGamesSelected={input.onMinGamesSelected}
-          />
-        </div>
-        <div className="archetype-details-wrapper">
-          <ArchetypeDetailsPanel
-            parsed={input.parsed}
-            decks={input.decks}
-            selectedArchetype={input.selectedArchetype}
-          />
-        </div>
+    <div className="analyze-page">
+      <SectionNav sections={ARCH_SECTIONS} />
+
+      <div className="controls-panel">
+        <span className="section-heading">Colors</span>
+        <ColorPickerHeader display={input.colorCheckboxes} onChecked={input.onColorChecked} />
       </div>
 
-      <div className="archetype-charts-section">
-        <div className="selector-group" style={{"justifyContent": "center", "marginBottom": "1rem"}}>
-          <DropdownHeader
-            label="Left Chart"
-            options={chartOptions}
-            value={leftChart}
-            onChange={(e) => setLeftChart(e.target.value)}
-          />
-          <DropdownHeader
-            label="Right Chart"
-            options={chartOptions}
-            value={rightChart}
-            onChange={(e) => setRightChart(e.target.value)}
-          />
+      <Section id="archetypes">
+        <ArchetypeStatsTable
+          parsed={input.parsed}
+          decks={input.decks}
+          dropdownSelection={input.colorTypeSelection}
+          sortBy={input.sortBy}
+          onHeaderClick={input.onHeaderClick}
+          handleRowClick={input.handleRowClick}
+          selectedArchetype={input.selectedArchetype}
+        />
+      </Section>
+
+      <Section id="selected-archetype" heading={`Selected — ${input.selectedArchetype}`}>
+        <TopCardsInArchetypeWidget
+          parsed={input.parsed}
+          cardData={input.cardData}
+          decks={input.decks}
+          minDrafts={input.minDrafts}
+          cube={input.cube}
+          minDecksInArch={input.minDecksInArch}
+          archetypeDropdownOptions={input.archetypeDropdownOptions}
+          selectedArchetype={input.selectedArchetype}
+          onArchetypeSelected={input.onArchetypeSelected}
+          colorWidgetOpts={input.colorWidgetOpts}
+          onColorSelected={input.onColorSelected}
+          colorSelection={input.colorSelection}
+          onMinDraftsSelected={input.onMinDraftsSelected}
+          onMinGamesSelected={input.onMinGamesSelected}
+        />
+        <ArchetypeDetailsPanel
+          parsed={input.parsed}
+          decks={input.decks}
+          selectedArchetype={input.selectedArchetype}
+        />
+      </Section>
+
+      <Section id="trends" heading="Trends">
+        <div className="controls-panel">
+          <div className="selector-group" style={{"justifyContent": "center"}}>
+            <DropdownHeader
+              label="Left Chart"
+              options={chartOptions}
+              value={leftChart}
+              onChange={(e) => setLeftChart(e.target.value)}
+            />
+            <DropdownHeader
+              label="Right Chart"
+              options={chartOptions}
+              value={rightChart}
+              onChange={(e) => setRightChart(e.target.value)}
+            />
+          </div>
         </div>
         <div className="chart-grid">
           {renderChart(leftChart)}
           {renderChart(rightChart)}
         </div>
-      </div>
+      </Section>
     </div>
   );
 }
@@ -344,18 +355,21 @@ function ArchetypeStatsTable(input) {
 
   return (
     <div>
-      <ColorPickerHeader display={input.colorCheckboxes} onChecked={input.onColorChecked} />
-      <h4 style={{marginTop: "1rem", marginBottom: "0.5rem"}}>Macro Archetypes</h4>
-      <table className="widget-table">
-        <ArchetypeTableHeader onHeaderClick={input.onHeaderClick} />
-        <ArchetypeTableRows data={macroData} sortBy={input.sortBy} handleRowClick={input.handleRowClick} />
-      </table>
-      {microData.length > 0 && <>
-        <h4 style={{marginTop: "1.5rem", marginBottom: "0.5rem"}}>Micro Archetypes</h4>
+      <h3 className="section-heading">Macro Archetypes</h3>
+      <div className="table-scroll">
         <table className="widget-table">
           <ArchetypeTableHeader onHeaderClick={input.onHeaderClick} />
-          <ArchetypeTableRows data={microData} sortBy={input.sortBy} handleRowClick={input.handleRowClick} />
+          <ArchetypeTableRows data={macroData} sortBy={input.sortBy} handleRowClick={input.handleRowClick} />
         </table>
+      </div>
+      {microData.length > 0 && <>
+        <h3 className="section-heading" style={{marginTop: "1.5rem"}}>Micro Archetypes</h3>
+        <div className="table-scroll">
+          <table className="widget-table">
+            <ArchetypeTableHeader onHeaderClick={input.onHeaderClick} />
+            <ArchetypeTableRows data={microData} sortBy={input.sortBy} handleRowClick={input.handleRowClick} />
+          </table>
+        </div>
       </>}
     </div>
   );
@@ -400,7 +414,7 @@ export function ColorPickerHeader(input) {
 
 function TopCardsInArchetypeWidgetOptions(input) {
   return (
-    <div className="selector-group" style={{"padding": "1rem", "background": "var(--card-background)", "borderBottom": "1px solid var(--border)"}}>
+    <div className="selector-group">
       <DropdownHeader
         label="Archetype"
         options={input.archetypeDropdownOptions}
@@ -494,8 +508,12 @@ function TopCardsInArchetypeWidget(input) {
   ]
 
   return (
-    <div className="widget-scroll">
-      <TopCardsInArchetypeWidgetOptions {...input} />
+    <div>
+      <div className="controls-panel">
+        <TopCardsInArchetypeWidgetOptions {...input} />
+      </div>
+      <h3 className="section-heading">Top Cards in Archetype</h3>
+      <div className="table-scroll">
       <table className="widget-table">
         <thead className="table-header">
           <tr>
@@ -563,6 +581,7 @@ function TopCardsInArchetypeWidget(input) {
         </tbody>
       </table>
       </div>
+    </div>
   );
 }
 
@@ -581,50 +600,58 @@ function ArchetypeDetailsPanel(input) {
     })
   }
   return (
-    <div>
-      <table className="widget-table">
-        <thead className="table-header">
-          <tr>
-            <td onClick={input.onHeaderClick} id="name" className="header-cell">Paired with</td>
-            <td onClick={input.onHeaderClick} id="num" className="header-cell">#</td>
-          </tr>
-        </thead>
-        <tbody>
-          {
-            sharedData.map(function(arch) {
-              return (
-                <tr key={arch.name} sort={arch.num} className="widget-table-row">
-                  <td key="name">{arch.name}</td>
-                  <td key="num">{arch.num}</td>
-                </tr>
-              )
-            }).sort(SortFunc)
-          }
-        </tbody>
-      </table>
+    <div className="detail-grid">
+      <div>
+        <h3 className="section-heading">Paired With</h3>
+        <div className="table-scroll">
+        <table className="widget-table">
+          <thead className="table-header">
+            <tr>
+              <td onClick={input.onHeaderClick} id="name" className="header-cell">Archetype</td>
+              <td onClick={input.onHeaderClick} id="num" className="header-cell">#</td>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              sharedData.map(function(arch) {
+                return (
+                  <tr key={arch.name} sort={arch.num} className="widget-table-row">
+                    <td key="name">{arch.name}</td>
+                    <td key="num">{arch.num}</td>
+                  </tr>
+                )
+              }).sort(SortFunc)
+            }
+          </tbody>
+        </table>
+        </div>
+      </div>
 
-      <br></br>
-
-      <table className="widget-table">
-        <thead className="table-header">
-          <tr>
-            <td onClick={input.onHeaderClick} id="name" className="header-cell">Played by</td>
-            <td onClick={input.onHeaderClick} id="num" className="header-cell">#</td>
-          </tr>
-        </thead>
-        <tbody>
-          {
-            playerData.map(function(player) {
-              return (
-                <tr key={player.name} sort={player.num} className="widget-table-row">
-                  <td key="name">{player.name}</td>
-                  <td key="num">{player.num}</td>
-                </tr>
-              )
-            }).sort(SortFunc)
-          }
-        </tbody>
-      </table>
+      <div>
+        <h3 className="section-heading">Played By</h3>
+        <div className="table-scroll">
+        <table className="widget-table">
+          <thead className="table-header">
+            <tr>
+              <td onClick={input.onHeaderClick} id="name" className="header-cell">Player</td>
+              <td onClick={input.onHeaderClick} id="num" className="header-cell">#</td>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              playerData.map(function(player) {
+                return (
+                  <tr key={player.name} sort={player.num} className="widget-table-row">
+                    <td key="name">{player.name}</td>
+                    <td key="num">{player.num}</td>
+                  </tr>
+                )
+              }).sort(SortFunc)
+            }
+          </tbody>
+        </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -199,17 +199,28 @@ table {
   border-color: var(--primary);
 }
 
+/* Small gap between the top navigation and the control bar below it. */
+.stats-root {
+  padding-top: 1rem;
+}
+
 /* Selector Bar Layout */
 .selectorbar {
   background: var(--card-background);
   padding: 1.5rem;
   border-radius: 12px;
-  margin: 1rem;
+  margin: 0 auto 1rem;
+  max-width: 1400px;
   border: 1px solid var(--border);
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+
+  /* Travels with the page so the filters/dates stay reachable while scrolling. */
+  position: sticky;
+  top: 0;
+  z-index: 100;
 }
 
 .selector-group {
@@ -221,6 +232,109 @@ table {
 
 .search-group {
   width: 100%;
+}
+
+/* Shared Analyze page shell. Every Analyze page lives in this centered column
+   so widths stop varying between them. */
+.analyze-page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 1rem 3rem;
+}
+
+/* Standard panel for a page's local controls (filters, dropdowns). */
+.controls-panel {
+  background: var(--card-background);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  margin: 1.5rem 0;
+}
+
+/* Section heading - matches the uppercase muted label style used elsewhere. */
+.section-heading {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  margin: 0 0 0.75rem 0;
+}
+
+/* A content block within a page. scroll-margin keeps anchor jumps clear of the
+   sticky section nav. */
+.page-section {
+  margin-bottom: 2.5rem;
+  scroll-margin-top: calc(var(--selectorbar-height, 0px) + 64px);
+}
+
+/* Two narrow tables side by side (e.g. paired-with / played-by). */
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+/* Cap tall tables so a long list scrolls within the panel instead of
+   stretching the page. Headers stay pinned while the rows scroll. */
+.table-scroll {
+  max-height: 1056px; /* ~20 rows at 48px + header */
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.table-scroll .widget-table {
+  border: none;
+  border-radius: 0;
+}
+
+.table-scroll thead.table-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+/* Side-by-side detail tables get a tighter cap so a long one (played-by)
+   doesn't tower over a short one (paired-with). */
+.detail-grid .table-scroll {
+  max-height: 600px;
+}
+
+/* In-page jump nav. Pins to the top once the controls scroll past it, and
+   highlights the section currently in view. */
+.section-nav {
+  position: sticky;
+  top: var(--selectorbar-height, 0px);
+  z-index: 90;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: var(--page-background);
+  padding: 0.6rem 0;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.section-nav a {
+  color: var(--text-muted);
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.section-nav a:hover {
+  color: var(--white);
+  background: var(--table-row-hover);
+}
+
+.section-nav a.active {
+  color: var(--primary);
+  background: var(--highlight);
 }
 
 .navigation-group {


### PR DESCRIPTION
Aligns the Analyze pages on a shared layout shell and rebuilds the Archetypes page (formerly Types) on it. Also fixes top cards showing nothing when a macro archetype is selected.