### PR TITLE
Reclassify tempo decks and drop tempo as a macro archetype

### DIFF
--- a/data/polyverse/2023-11-16_local_1/dom.json
+++ b/data/polyverse/2023-11-16_local_1/dom.json
@@ -4,7 +4,7 @@
   "draft_id": "2023-11-16_local_1",
   "combined_file": "data/polyverse/2023-11-16_local_1/dom.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "spells",
   "+1/+1"

--- a/data/polyverse/2023-12-02_local_1/jen.json
+++ b/data/polyverse/2023-12-02_local_1/jen.json
@@ -4,7 +4,7 @@
   "draft_id": "2023-12-02_local_1",
   "combined_file": "data/polyverse/2023-12-02_local_1/jen.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2024-01-07_local_1/xander.json
+++ b/data/polyverse/2024-01-07_local_1/xander.json
@@ -4,7 +4,7 @@
   "draft_id": "2024-01-07_local_1",
   "combined_file": "data/polyverse/2024-01-07_local_1/xander.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2024-03-28_local_1/matthewbk.json
+++ b/data/polyverse/2024-03-28_local_1/matthewbk.json
@@ -4,7 +4,7 @@
   "draft_id": "2024-03-28_local_1",
   "combined_file": "data/polyverse/2024-03-28_local_1/matthewbk.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [],
  "player": "matthewbk",
  "date": "2024-03-28",

--- a/data/polyverse/2024-03-31_local_1/james.json
+++ b/data/polyverse/2024-03-31_local_1/james.json
@@ -4,7 +4,7 @@
   "draft_id": "2024-03-31_local_1",
   "combined_file": "data/polyverse/2024-03-31_local_1/james.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [],
  "player": "james",
  "date": "2024-03-31",

--- a/data/polyverse/2024-04-24_local_1/dom.json
+++ b/data/polyverse/2024-04-24_local_1/dom.json
@@ -4,7 +4,7 @@
   "draft_id": "2024-04-24_local_1",
   "combined_file": "data/polyverse/2024-04-24_local_1/dom.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "discard"
  ],

--- a/data/polyverse/2024-05-14_local_1/casey.json
+++ b/data/polyverse/2024-05-14_local_1/casey.json
@@ -4,7 +4,7 @@
   "draft_id": "2024-05-14_local_1",
   "combined_file": "data/polyverse/2024-05-14_local_1/casey.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "aggro",
  "labels": [
   "taxes"
  ],

--- a/data/polyverse/2024-06-28_local_1/casey.json
+++ b/data/polyverse/2024-06-28_local_1/casey.json
@@ -4,7 +4,7 @@
   "draft_id": "2024-06-28_local_1",
   "combined_file": "data/polyverse/2024-06-28_local_1/casey.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "spells",
   "discard"

--- a/data/polyverse/2024-11-09_local_1/jen.json
+++ b/data/polyverse/2024-11-09_local_1/jen.json
@@ -4,7 +4,7 @@
   "draft_id": "2024-11-09_local_1",
   "combined_file": "data/polyverse/2024-11-09_local_1/jen.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2025-05-26_local_1/cara.json
+++ b/data/polyverse/2025-05-26_local_1/cara.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-05-26_local_1",
   "combined_file": "data/polyverse/2025-05-26_local_1/cara.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "aggro",
  "labels": [],
  "player": "cara",
  "date": "2025-05-26",

--- a/data/polyverse/2025-05-26_local_1/casey.json
+++ b/data/polyverse/2025-05-26_local_1/casey.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-05-26_local_1",
   "combined_file": "data/polyverse/2025-05-26_local_1/casey.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "draw",
   "discard"

--- a/data/polyverse/2025-05-26_local_1/james.json
+++ b/data/polyverse/2025-05-26_local_1/james.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-05-26_local_1",
   "combined_file": "data/polyverse/2025-05-26_local_1/james.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "aggro",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2025-06-12_local_1/colton.json
+++ b/data/polyverse/2025-06-12_local_1/colton.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-06-12_local_1",
   "combined_file": "data/polyverse/2025-06-12_local_1/colton.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2025-06-12_local_1/joe.json
+++ b/data/polyverse/2025-06-12_local_1/joe.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-06-12_local_1",
   "combined_file": "data/polyverse/2025-06-12_local_1/joe.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "aggro",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2025-06-12_local_1/kenny.json
+++ b/data/polyverse/2025-06-12_local_1/kenny.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-06-12_local_1",
   "combined_file": "data/polyverse/2025-06-12_local_1/kenny.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "aggro",
  "labels": [
   "sacrifice",
   "token"

--- a/data/polyverse/2025-06-12_local_1/sebastian.json
+++ b/data/polyverse/2025-06-12_local_1/sebastian.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-06-12_local_1",
   "combined_file": "data/polyverse/2025-06-12_local_1/sebastian.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "aggro",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2025-06-29_local_1/joe2.json
+++ b/data/polyverse/2025-06-29_local_1/joe2.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-06-29_local_1",
   "combined_file": "data/polyverse/2025-06-29_local_1/joe2.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "aggro",
  "labels": [
   "flicker",
   "coco"

--- a/data/polyverse/2025-06-29_local_1/zephyr.json
+++ b/data/polyverse/2025-06-29_local_1/zephyr.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-06-29_local_1",
   "combined_file": "data/polyverse/2025-06-29_local_1/zephyr.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2025-08-17_local_1/wilson.json
+++ b/data/polyverse/2025-08-17_local_1/wilson.json
@@ -4,7 +4,7 @@
   "draft_id": "2025-08-17_local_1",
   "combined_file": "data/polyverse/2025-08-17_local_1/wilson.csv"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2025-10-04_ccc2025_1/2025-10-04_ccc2025_1-p2.json
+++ b/data/polyverse/2025-10-04_ccc2025_1/2025-10-04_ccc2025_1-p2.json
@@ -134,5 +134,5 @@
   "Murderous Cut",
   "Bloodchief's Thirst"
  ],
- "macro_archetype": "tempo"
+ "macro_archetype": "aggro"
 }

--- a/data/polyverse/2025-10-04_ccc2025_1/2025-10-04_ccc2025_1-p3.json
+++ b/data/polyverse/2025-10-04_ccc2025_1/2025-10-04_ccc2025_1-p3.json
@@ -133,5 +133,5 @@
   "Warden of the Inner Sky",
   "Scavenging Ooze"
  ],
- "macro_archetype": "tempo"
+ "macro_archetype": "aggro"
 }

--- a/data/polyverse/2025-10-04_ccc2025_1/2025-10-04_ccc2025_1-p6.json
+++ b/data/polyverse/2025-10-04_ccc2025_1/2025-10-04_ccc2025_1-p6.json
@@ -117,5 +117,5 @@
   "Grim Discovery",
   "Overgrown Tomb"
  ],
- "macro_archetype": "tempo"
+ "macro_archetype": "aggro"
 }

--- a/data/polyverse/2025-10-04_ccc2025_2/2025-10-04_ccc2025_2-p5.json
+++ b/data/polyverse/2025-10-04_ccc2025_2/2025-10-04_ccc2025_2-p5.json
@@ -125,5 +125,5 @@
   "Twinshot Sniper",
   "Flame Jab"
  ],
- "macro_archetype": "tempo"
+ "macro_archetype": "midrange"
 }

--- a/data/polyverse/2025-10-04_ccc2025_2/2025-10-04_ccc2025_2-p8.json
+++ b/data/polyverse/2025-10-04_ccc2025_2/2025-10-04_ccc2025_2-p8.json
@@ -131,5 +131,5 @@
   "Scrabbling Claws",
   "Man-o'-War"
  ],
- "macro_archetype": "tempo"
+ "macro_archetype": "midrange"
 }

--- a/data/polyverse/2025-10-04_ccc2025_3/2025-10-04_ccc2025_3-p4.json
+++ b/data/polyverse/2025-10-04_ccc2025_3/2025-10-04_ccc2025_3-p4.json
@@ -121,5 +121,5 @@
   "Kor Skyfisher",
   "Fire // Ice"
  ],
- "macro_archetype": "tempo"
+ "macro_archetype": "midrange"
 }

--- a/data/polyverse/2025-10-04_ccc2025_3/2025-10-04_ccc2025_3-p8.json
+++ b/data/polyverse/2025-10-04_ccc2025_3/2025-10-04_ccc2025_3-p8.json
@@ -121,5 +121,5 @@
   "Wooded Foothills",
   "Arid Mesa"
  ],
- "macro_archetype": "tempo"
+ "macro_archetype": "midrange"
 }

--- a/data/polyverse/2026-01-03_local_1/casey.json
+++ b/data/polyverse/2026-01-03_local_1/casey.json
@@ -5,7 +5,7 @@
   "mainboard_file": "data/polyverse/2026-01-03_local_1/casey-mainboard.txt",
   "sideboard_file": "data/polyverse/2026-01-03_local_1/casey-sideboard.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "aggro",
  "labels": [
   "token"
  ],

--- a/data/polyverse/2026-01-03_local_1/jackson.json
+++ b/data/polyverse/2026-01-03_local_1/jackson.json
@@ -5,7 +5,7 @@
   "mainboard_file": "data/polyverse/2026-01-03_local_1/jackson-mainboard.txt",
   "sideboard_file": "data/polyverse/2026-01-03_local_1/jackson-sideboard.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "draw",
   "skimmer",

--- a/data/polyverse/2026-01-03_local_1/kaiyo.json
+++ b/data/polyverse/2026-01-03_local_1/kaiyo.json
@@ -5,7 +5,7 @@
   "mainboard_file": "data/polyverse/2026-01-03_local_1/kaiyo-mainboard.txt",
   "sideboard_file": "data/polyverse/2026-01-03_local_1/kaiyo-sideboard.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "artifacts",
   "sacrifice"

--- a/data/polyverse/2026-01-17_p1p12026_1/2026-01-17_p1p12026_1-p6.json
+++ b/data/polyverse/2026-01-17_p1p12026_1/2026-01-17_p1p12026_1-p6.json
@@ -4,7 +4,7 @@
   "draft_id": "2026-01-17_p1p12026_1",
   "pool_file": "data/polyverse/2026-01-17_p1p12026_1/20260117-210a-pool.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2026-01-18_p1p12026_1/2026-01-18_p1p12026_1-p7.json
+++ b/data/polyverse/2026-01-18_p1p12026_1/2026-01-18_p1p12026_1-p7.json
@@ -4,7 +4,7 @@
   "draft_id": "2026-01-18_p1p12026_1",
   "combined_file": "data/polyverse/2026-01-18_p1p12026_1/20260118d1-210a.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2026-01-18_p1p12026_2/2026-01-18_p1p12026_2-p4.json
+++ b/data/polyverse/2026-01-18_p1p12026_2/2026-01-18_p1p12026_2-p4.json
@@ -4,7 +4,7 @@
   "draft_id": "2026-01-18_p1p12026_2",
   "combined_file": "data/polyverse/2026-01-18_p1p12026_2/20260118d2-120a.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "spells"
  ],

--- a/data/polyverse/2026-01-18_p1p12026_2/2026-01-18_p1p12026_2-p6.json
+++ b/data/polyverse/2026-01-18_p1p12026_2/2026-01-18_p1p12026_2-p6.json
@@ -4,7 +4,7 @@
   "draft_id": "2026-01-18_p1p12026_2",
   "pool_file": "data/polyverse/2026-01-18_p1p12026_2/20260118d2-030-pool.txt"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [],
  "player": "2026-01-18_p1p12026_2-p6",
  "date": "2026-01-18",

--- a/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p8.json
+++ b/data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p8.json
@@ -3,7 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_1/2026-06-20_bcp26_1-p8.json",
   "draft_id": "2026-06-20_bcp26_1"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "valiant",
   "heartfire",

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p1.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p1.json
@@ -3,7 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p1.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "draw",
   "skimmer"

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p2.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p2.json
@@ -3,7 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p2.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "delney"
  ],

--- a/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p8.json
+++ b/data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p8.json
@@ -3,7 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_2/2026-06-20_bcp26_2-p8.json",
   "draft_id": "2026-06-20_bcp26_2"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "sacrifice",
   "spells"

--- a/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p2.json
+++ b/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p2.json
@@ -3,7 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p2.json",
   "draft_id": "2026-06-20_bcp26_3"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [
   "token"
  ],

--- a/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p4.json
+++ b/data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p4.json
@@ -3,7 +3,7 @@
   "path": "data/polyverse/2026-06-20_bcp26_3/2026-06-20_bcp26_3-p4.json",
   "draft_id": "2026-06-20_bcp26_3"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "draw",
   "spells"

--- a/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p1.json
+++ b/data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p1.json
@@ -3,7 +3,7 @@
   "path": "data/polyverse/2026-06-21_bcp26_1/2026-06-21_bcp26_1-p1.json",
   "draft_id": "2026-06-21_bcp26_1"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "midrange",
  "labels": [],
  "player": "2026-06-21_bcp26_1-p1",
  "date": "2026-06-21",

--- a/data/polyverse/2026-06-21_bcp26_2/2026-06-21_bcp26_2-p7.json
+++ b/data/polyverse/2026-06-21_bcp26_2/2026-06-21_bcp26_2-p7.json
@@ -3,7 +3,7 @@
   "path": "data/polyverse/2026-06-21_bcp26_2/2026-06-21_bcp26_2-p7.json",
   "draft_id": "2026-06-21_bcp26_2"
  },
- "macro_archetype": "tempo",
+ "macro_archetype": "control",
  "labels": [
   "spells"
  ],

--- a/pkg/commands/parse.go
+++ b/pkg/commands/parse.go
@@ -119,7 +119,7 @@ func parseDeck(deckFiles []string, who, labels, date, draftID string) (*types.De
 		return nil, fmt.Errorf("Too many card sets (%d) found in deck files: %v", len(cardSets), deckFiles)
 	}
 
-	// Build the deck struct. Macro archetype values (aggro/midrange/tempo/control)
+	// Build the deck struct. Macro archetype values (aggro/midrange/control)
 	// passed through --labels are auto-promoted to the dedicated field so callers
 	// don't need to keep them in sync.
 	d := types.NewDeck()
@@ -127,7 +127,7 @@ func parseDeck(deckFiles []string, who, labels, date, draftID string) (*types.De
 		for _, l := range strings.Split(labels, ",") {
 			l = strings.TrimSpace(l)
 			switch strings.ToLower(l) {
-			case "aggro", "midrange", "tempo", "control":
+			case "aggro", "midrange", "control":
 				d.MacroArchetype = strings.ToLower(l)
 			default:
 				d.Labels = append(d.Labels, l)

--- a/pkg/server/stats/archetypes.go
+++ b/pkg/server/stats/archetypes.go
@@ -74,14 +74,14 @@ func (s *archetypeStatsHandler) ServeHTTP(rw http.ResponseWriter, r *http.Reques
 	}
 
 	// Initialize macro archetypes.
-	macros := []string{"aggro", "midrange", "control", "tempo"}
+	macros := []string{"aggro", "midrange", "control"}
 	for _, m := range macros {
 		resp.Archetypes[m] = &ArchetypeStats{Type: m, SharedWith: make(map[string]int), Players: make(map[string]int)}
 	}
 
 	// totalWins counts each game once (used for TotalGames display).
 	// percentOfWinsDenom is inflated the same way as.Wins is: a deck labeled both
-	// "tempo" and "control" contributes its wins to both buckets and to the
+	// "aggro" and "control" contributes its wins to both buckets and to the
 	// denominator twice, so PercentOfWins actually sums to 100% across rows.
 	totalWins := 0
 	percentOfWinsDenom := 0

--- a/pkg/server/stats/archetypes_test.go
+++ b/pkg/server/stats/archetypes_test.go
@@ -73,15 +73,15 @@ func foldGamesIntoMatches(d *storage.Deck, player string, games []types.Game) {
 	}
 }
 
-// --- SharedWith: "tempo" excluded ---
+// --- SharedWith: macro archetype excluded ---
 
-func TestArchetypeStats_SharedWith_TempoSkip(t *testing.T) {
+func TestArchetypeStats_SharedWith_MacroSkip(t *testing.T) {
 	d := makeStorageDeck("Alice", "d1", []string{"spells"}, []types.Game{
 		{Opponent: "Bob", Winner: "Alice"},
 	}, []types.Match{
 		{Opponent: "Bob", Winner: "Alice"},
 	})
-	d.MacroArchetype = "tempo"
+	d.MacroArchetype = "control"
 	decks := []*storage.Deck{d}
 
 	handler := &archetypeStatsHandler{store: &mockDeckStorage{decks: decks}}
@@ -93,18 +93,16 @@ func TestArchetypeStats_SharedWith_TempoSkip(t *testing.T) {
 	err := json.Unmarshal(rr.Body.Bytes(), &resp)
 	assert.NoError(t, err)
 
-	// "spells" archetype's SharedWith should NOT contain "tempo"
+	// The macro archetype must not leak into a secondary label's SharedWith.
 	spells := resp.Archetypes["spells"]
 	assert.NotNil(t, spells)
-	_, hasTempo := spells.SharedWith["tempo"]
-	assert.False(t, hasTempo, "tempo should be excluded from SharedWith")
+	_, hasControl := spells.SharedWith["control"]
+	assert.False(t, hasControl, "macro archetype should be excluded from SharedWith")
 
-	// "tempo" archetype's SharedWith should NOT contain "spells" macro entries
-	// but should contain non-macro labels... wait, actually "tempo" IS a macro.
-	// For the "tempo" label, SharedWith should include "spells"
-	tempo := resp.Archetypes["tempo"]
-	assert.NotNil(t, tempo)
-	assert.Equal(t, 1, tempo.SharedWith["spells"])
+	// The macro archetype's own SharedWith does include secondary labels.
+	control := resp.Archetypes["control"]
+	assert.NotNil(t, control)
+	assert.Equal(t, 1, control.SharedWith["spells"])
 }
 
 // --- WinPercent ---
@@ -166,13 +164,13 @@ func TestArchetypeStats_TotalGames(t *testing.T) {
 	assert.Equal(t, 2, resp.TotalGames)
 }
 
-// A deck labeled both "tempo" and "control" contributes its wins to both
+// A deck labeled both "aggro" and "control" contributes its wins to both
 // buckets. The PercentOfWins denominator must inflate the same way so the
 // column actually sums to ~100% across rows. Small drift comes from
 // per-row math.Round and is bounded by the number of rows.
 func TestArchetypeStats_PercentOfWinsSumsTo100(t *testing.T) {
 	decks := []*storage.Deck{
-		makeStorageDeck("Alice", "d1", []string{"tempo", "control"}, []types.Game{
+		makeStorageDeck("Alice", "d1", []string{"aggro", "control"}, []types.Game{
 			{Opponent: "Bob", Winner: "Alice"},
 			{Opponent: "Bob", Winner: "Alice"},
 		}, nil),

--- a/pkg/server/stats/cards.go
+++ b/pkg/server/stats/cards.go
@@ -234,7 +234,7 @@ func (d *cardStatsHandler) statsForDecks(decks []*storage.Deck, cubeCards map[st
 
 			// Include archetype data for this card. The macro archetype is counted
 			// alongside the secondary labels so selecting a macro (aggro/midrange/
-			// control/tempo) matches the cards played in it.
+			// control) matches the cards played in it.
 			for _, l := range deck.Labels {
 				cbn.Archetypes[l]++
 			}
@@ -691,13 +691,11 @@ func newCardStats(c types.Card) *cardStats {
 			"aggro":    {},
 			"midrange": {},
 			"control":  {},
-			"tempo":    {},
 		},
 		AgainstArchetype: map[string]*winStats{
 			"aggro":    {},
 			"midrange": {},
 			"control":  {},
-			"tempo":    {},
 		},
 	}
 }

--- a/pkg/server/stats/health.go
+++ b/pkg/server/stats/health.go
@@ -101,9 +101,9 @@ func (h *healthStatsHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 }
 
 // archetypeEvenness computes Shannon entropy of macro archetype distribution,
-// normalized by log(4) to produce a 0-1 scale.
+// normalized by log(3) to produce a 0-1 scale.
 func archetypeEvenness(allDecks []*storage.Deck) float64 {
-	macros := []string{"aggro", "midrange", "control", "tempo"}
+	macros := []string{"aggro", "midrange", "control"}
 	counts := make(map[string]int)
 	for _, m := range macros {
 		counts[m] = 0
@@ -211,7 +211,7 @@ func indexOf(s, sub string) int {
 
 // trophyGini computes the Gini coefficient of trophy counts across macro archetypes.
 func trophyGini(allDecks []*storage.Deck) float64 {
-	macros := []string{"aggro", "midrange", "control", "tempo"}
+	macros := []string{"aggro", "midrange", "control"}
 	trophyCounts := make(map[string]int)
 	for _, m := range macros {
 		trophyCounts[m] = 0

--- a/pkg/types/deck.go
+++ b/pkg/types/deck.go
@@ -233,7 +233,7 @@ type Deck struct {
 	Metadata Metadata `json:"metadata"`
 
 	// MacroArchetype is the deck's high-level strategy classification.
-	// Expected values: "aggro", "midrange", "tempo", "control", or empty.
+	// Expected values: "aggro", "midrange", "control", or empty.
 	MacroArchetype string `json:"macro_archetype,omitempty"`
 
 	// Tags represents metadata associated with this deck. Used for
@@ -414,7 +414,7 @@ func (d *Deck) AddGame(opponent, winner string) {
 }
 
 func (d *Deck) Macro() string {
-	// Return one of "aggro", "midrange", "control", "tempo", or "".
+	// Return one of "aggro", "midrange", "control", or "".
 	// Prefer the dedicated field; fall back to scanning Labels for decks
 	// that haven't been backfilled yet.
 	if d.MacroArchetype != "" {
@@ -422,7 +422,7 @@ func (d *Deck) Macro() string {
 	}
 	for _, label := range d.Labels {
 		switch strings.ToLower(label) {
-		case "aggro", "midrange", "control", "tempo":
+		case "aggro", "midrange", "control":
 			return strings.ToLower(label)
 		}
 	}

--- a/pkg/types/deck_test.go
+++ b/pkg/types/deck_test.go
@@ -281,7 +281,7 @@ func TestMacro(t *testing.T) {
 		{"aggro", []string{"RDW", "aggro"}, "aggro"},
 		{"midrange", []string{"Midrange", "value"}, "midrange"},
 		{"control", []string{"draw-go", "Control"}, "control"},
-		{"tempo", []string{"Tempo", "flash"}, "tempo"},
+		{"tempo no longer a macro", []string{"Tempo", "flash"}, ""},
 		{"no macro", []string{"reanimator", "graveyard"}, ""},
 		{"empty", nil, ""},
 	}

--- a/ui/src/pages/DeckViewer.js
+++ b/ui/src/pages/DeckViewer.js
@@ -397,7 +397,6 @@ function getMacro(deck) {
     case "aggro": return "Aggro"
     case "midrange": return "Midrange"
     case "control": return "Control"
-    case "tempo": return "Tempo"
     default: return "N/A"
   }
 }
@@ -1009,7 +1008,6 @@ function PlayerFrame(input) {
               { label: "—", value: "" },
               { label: "Aggro", value: "aggro" },
               { label: "Midrange", value: "midrange" },
-              { label: "Tempo", value: "tempo" },
               { label: "Control", value: "control" },
             ]}
             onChange={(e) => commit({ macro: e.target.value })}

--- a/ui/src/pages/Health.js
+++ b/ui/src/pages/Health.js
@@ -46,7 +46,7 @@ export function HealthWidget(input) {
             color="rgba(75, 192, 192, 1)"
             min={0}
             max={1}
-            description="Shannon entropy of macro archetype distribution (aggro/midrange/control/tempo), normalized 0-1. Higher = more balanced."
+            description="Shannon entropy of macro archetype distribution (aggro/midrange/control), normalized 0-1. Higher = more balanced."
           />
         </div>
         <div style={{height: "500px"}}>

--- a/ui/src/pages/Types.js
+++ b/ui/src/pages/Types.js
@@ -71,7 +71,6 @@ export function ArchetypeWidget(input) {
     { label: "Macro Last Place %", value: "macro_lastplace_pct" },
     { label: "Macro CMC", value: "macro_cmc" },
     { label: "Matchup: Aggro", value: "matchup_aggro" },
-    { label: "Matchup: Tempo", value: "matchup_tempo" },
     { label: "Matchup: Midrange", value: "matchup_midrange" },
     { label: "Matchup: Control", value: "matchup_control" },
     { label: "Pie: Builds", value: "pie_builds" },
@@ -95,7 +94,6 @@ export function ArchetypeWidget(input) {
       case "macro_lastplace_pct": return <MacroArchetypesChart parsed={input.parsed} decks={input.decks} bucketSize={input.bucketSize} dataset="lastplace_pct" />;
       case "macro_cmc": return <MacroArchetypesChart parsed={input.parsed} decks={input.decks} bucketSize={input.bucketSize} dataset="cmc" />;
       case "matchup_aggro": return <WinsByMatchup focus="aggro" matchups={input.matchups} />;
-      case "matchup_tempo": return <WinsByMatchup focus="tempo" matchups={input.matchups} />;
       case "matchup_midrange": return <WinsByMatchup focus="midrange" matchups={input.matchups} />;
       case "matchup_control": return <WinsByMatchup focus="control" matchups={input.matchups} />;
       case "pie_builds": return <MacroArchetypesPieChart parsed={input.parsed} decks={input.decks} dataset="builds" />;
@@ -181,7 +179,7 @@ export function ArchetypeWidget(input) {
   );
 }
 
-const macroArchetypes = new Set(["aggro", "tempo", "midrange", "control"]);
+const macroArchetypes = new Set(["aggro", "midrange", "control"]);
 
 const archetypeHeaders = [
   {
@@ -685,12 +683,11 @@ export function ArchetypeData(decks) {
   let totalGames = 0
   let tracker = new Map()
 
-  // We set aggro/midrange/control/tempo for every set of decks, even if they are
+  // We set aggro/midrange/control for every set of decks, even if they are
   // zeroed out. This enables graphs that expect these to exist.
   tracker.set("aggro", newType("aggro"))
   tracker.set("midrange", newType("midrange"))
   tracker.set("control", newType("control"))
-  tracker.set("tempo", newType("tempo"))
 
   for (let deck of decks) {
     // We only need to count wins, because every loss is counted in another deck as a win.
@@ -790,7 +787,6 @@ function MicroArchetypesChart(input) {
   archSet.delete("aggro")
   archSet.delete("midrange")
   archSet.delete("control")
-  archSet.delete("tempo")
 
   // We want to fitler out any archtetypes that don't meet a minimum
   // criteria, in order to de-clutter the plots. Use aggregate data across all buckets
@@ -999,7 +995,7 @@ function MacroArchetypesChart(input) {
   }
 
   // Parse the buckets.
-  let archs = ["aggro", "midrange", "control", "tempo"]
+  let archs = ["aggro", "midrange", "control"]
   let datasets = new Map()
   for (let arch of archs) {
     datasets.set(arch, [])
@@ -1057,12 +1053,6 @@ function MacroArchetypesChart(input) {
         data: datasets.get("control"),
         borderColor: Colors.get("U"),
         backgroundColor: Colors.get("U"),
-      },
-      {
-        label: 'Tempo',
-        data: datasets.get("tempo"),
-        borderColor: Colors.get("B"),
-        backgroundColor: Colors.get("B"),
       },
   ]
 
@@ -1128,7 +1118,6 @@ function MacroArchetypesPieChart(input) {
     stats.get("aggro").count,
     stats.get("midrange").count,
     stats.get("control").count,
-    stats.get("tempo").count,
   ]
 
   switch (input.dataset) {
@@ -1138,12 +1127,11 @@ function MacroArchetypesPieChart(input) {
         stats.get("aggro").wins,
         stats.get("midrange").wins,
         stats.get("control").wins,
-        stats.get("tempo").wins,
       ]
   }
 
   let data = {
-    labels: ['Aggro', 'Midrange', 'Control', 'Tempo'],
+    labels: ['Aggro', 'Midrange', 'Control'],
     datasets: [
       {
         label: title,
@@ -1152,13 +1140,11 @@ function MacroArchetypesPieChart(input) {
           'rgba(255, 99, 132, 0.2)',
           'rgba(255, 206, 86, 0.2)',
           'rgba(54, 162, 235, 0.2)',
-          'rgba(94, 122, 135, 0.2)',
         ],
         borderColor: [
           'rgba(255, 99, 132, 1)',
           'rgba(255, 206, 86, 1)',
           'rgba(54, 162, 235, 1)',
-          'rgba(94, 122, 135, 1)',
         ],
         borderWidth: 1,
       },
@@ -1232,8 +1218,7 @@ function WinsByMatchup(input) {
     },
   };
 
-  // Sort the vs. by relative "speed" - i.e., aggro, tempo,
-  // midrange, control.
+  // Sort the vs. by relative "speed" - i.e., aggro, midrange, control.
   let versus = new Array()
   let find = function(t) {
     if (matchup.versus == null) {
@@ -1258,7 +1243,7 @@ function WinsByMatchup(input) {
     }
   }
 
-  let ats = ["aggro", "tempo", "midrange", "control"]
+  let ats = ["aggro", "midrange", "control"]
   for (let n of ats) {
     if (n == matchup.name) {
       continue;


### PR DESCRIPTION
Reclassifies the 41 decks previously labeled tempo into aggro/midrange/control - tempo wasn't separable from the other three. Drops tempo as a macro archetype across the API, stats, health metrics, and UI.